### PR TITLE
feat: animal-service 기본 CRUD 기능 구현

### DIFF
--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/JpaConfig.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.pawbridge.animalservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/controller/AnimalController.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/controller/AnimalController.java
@@ -1,0 +1,171 @@
+package com.pawbridge.animalservice.controller;
+
+import com.pawbridge.animalservice.dto.request.CreateAnimalRequest;
+import com.pawbridge.animalservice.dto.request.UpdateAnimalDescriptionRequest;
+import com.pawbridge.animalservice.dto.request.UpdateAnimalStatusRequest;
+import com.pawbridge.animalservice.dto.response.AnimalDetailResponse;
+import com.pawbridge.animalservice.dto.response.AnimalResponse;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.Species;
+import com.pawbridge.animalservice.facade.AnimalFacade;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 동물 정보 REST API 컨트롤러
+ * - 동물 CRUD, 검색, 필터링
+ * - Controller는 요청 받고 Facade에 전달, 응답 반환만 담당
+ */
+@RestController
+@RequestMapping("/api/animals")
+@RequiredArgsConstructor
+public class AnimalController {
+
+    private final AnimalFacade animalFacade;
+
+    /**
+     * 동물 등록 (보호소 회원/관리자)
+     * - POST /api/animals
+     */
+    @PostMapping
+    public ResponseEntity<AnimalDetailResponse> createAnimal(
+            @Valid @RequestBody CreateAnimalRequest request
+    ) {
+        AnimalDetailResponse response = animalFacade.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 동물 목록 조회 (필터링 + 페이징)
+     * - GET /api/animals
+     */
+    @GetMapping
+    public ResponseEntity<Page<AnimalResponse>> listAnimals(
+            @RequestParam(required = false) Species species,
+            @RequestParam(required = false) Gender gender,
+            @RequestParam(required = false) AnimalStatus status,
+            @RequestParam(required = false) String breed,
+            @RequestParam(required = false) Long shelterId,
+            @PageableDefault(size = 20, sort = "noticeEndDate", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<AnimalResponse> response;
+
+        // 필터 조건에 따라 적절한 Facade 메서드 호출
+        if (shelterId != null && status != null) {
+            response = animalFacade.findByShelterIdAndStatus(shelterId, status, pageable);
+        } else if (shelterId != null && species != null) {
+            response = animalFacade.findByShelterIdAndSpecies(shelterId, species, pageable);
+        } else if (shelterId != null) {
+            response = animalFacade.findByShelterId(shelterId, pageable);
+        } else if (species != null && status != null) {
+            response = animalFacade.findBySpeciesAndStatus(species, status, pageable);
+        } else if (species != null && gender != null) {
+            response = animalFacade.findBySpeciesAndGender(species, gender, pageable);
+        } else if (species != null && breed != null) {
+            response = animalFacade.searchBySpeciesAndBreed(species, breed, pageable);
+        } else if (species != null) {
+            response = animalFacade.findBySpecies(species, pageable);
+        } else if (status != null) {
+            response = animalFacade.findByStatus(status, pageable);
+        } else if (breed != null) {
+            response = animalFacade.searchByBreed(breed, pageable);
+        } else {
+            // 기본: 공고 종료 임박순 (메인 페이지)
+            response = animalFacade.findNoticeAnimalsOrderByNoticeEndDate(pageable);
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 동물 상세 조회
+     * - GET /api/animals/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<AnimalDetailResponse> getAnimal(@PathVariable Long id) {
+        AnimalDetailResponse response = animalFacade.findById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 동물 상태 변경
+     * - PATCH /api/animals/{id}/status
+     */
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<AnimalDetailResponse> updateStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateAnimalStatusRequest request
+    ) {
+        AnimalDetailResponse response = animalFacade.updateStatus(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 동물 설명 수정
+     * - PATCH /api/animals/{id}/description
+     */
+    @PatchMapping("/{id}/description")
+    public ResponseEntity<AnimalDetailResponse> updateDescription(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateAnimalDescriptionRequest request
+    ) {
+        AnimalDetailResponse response = animalFacade.updateDescription(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 동물 삭제
+     * - DELETE /api/animals/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteAnimal(@PathVariable Long id) {
+        animalFacade.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 공고 종료 임박 동물 조회 (D-3 이내)
+     * - GET /api/animals/expiring-soon
+     */
+    @GetMapping("/expiring-soon")
+    public ResponseEntity<Page<AnimalResponse>> listExpiringSoon(
+            @PageableDefault(size = 20, sort = "noticeEndDate", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<AnimalResponse> response = animalFacade.findExpiringSoonAnimals(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특징 키워드 검색
+     * - GET /api/animals/search/special-mark?keyword=순함
+     */
+    @GetMapping("/search/special-mark")
+    public ResponseEntity<Page<AnimalResponse>> searchBySpecialMark(
+            @RequestParam String keyword,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<AnimalResponse> response = animalFacade.searchBySpecialMark(keyword, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 발견 장소 검색
+     * - GET /api/animals/search/happen-place?place=서울
+     */
+    @GetMapping("/search/happen-place")
+    public ResponseEntity<Page<AnimalResponse>> searchByHappenPlace(
+            @RequestParam String place,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<AnimalResponse> response = animalFacade.searchByHappenPlace(place, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/controller/ShelterController.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/controller/ShelterController.java
@@ -1,0 +1,128 @@
+package com.pawbridge.animalservice.controller;
+
+import com.pawbridge.animalservice.dto.request.CreateShelterRequest;
+import com.pawbridge.animalservice.dto.request.UpdateShelterRequest;
+import com.pawbridge.animalservice.dto.response.ShelterDetailResponse;
+import com.pawbridge.animalservice.dto.response.ShelterResponse;
+import com.pawbridge.animalservice.facade.ShelterFacade;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 보호소 정보 REST API 컨트롤러
+ * - 보호소 CRUD, 검색
+ * - Controller는 요청 받고 Facade에 전달, 응답 반환만 담당
+ */
+@RestController
+@RequestMapping("/api/shelters")
+@RequiredArgsConstructor
+public class ShelterController {
+
+    private final ShelterFacade shelterFacade;
+
+    /**
+     * 보호소 등록 (관리자)
+     * - POST /api/shelters
+     */
+    @PostMapping
+    public ResponseEntity<ShelterDetailResponse> createShelter(
+            @Valid @RequestBody CreateShelterRequest request
+    ) {
+        ShelterDetailResponse response = shelterFacade.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 보호소 목록 조회 (필터링 + 페이징)
+     * - GET /api/shelters
+     */
+    @GetMapping
+    public ResponseEntity<Page<ShelterResponse>> listShelters(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String address,
+            @RequestParam(required = false) String organizationName,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = 20, sort = "name", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<ShelterResponse> response;
+
+        // 필터 조건에 따라 적절한 Facade 메서드 호출
+        if (keyword != null) {
+            // 통합 검색 (이름 또는 주소)
+            response = shelterFacade.searchByNameOrAddress(keyword, pageable);
+        } else if (name != null) {
+            response = shelterFacade.searchByName(name, pageable);
+        } else if (address != null) {
+            response = shelterFacade.searchByAddress(address, pageable);
+        } else if (organizationName != null) {
+            response = shelterFacade.searchByOrganizationName(organizationName, pageable);
+        } else {
+            // 전체 조회
+            response = shelterFacade.findAll(pageable);
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 보호소 상세 조회
+     * - GET /api/shelters/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ShelterDetailResponse> getShelter(@PathVariable Long id) {
+        ShelterDetailResponse response = shelterFacade.findById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 보호소 등록번호로 조회
+     * - GET /api/shelters/by-care-reg-no/{careRegNo}
+     */
+    @GetMapping("/by-care-reg-no/{careRegNo}")
+    public ResponseEntity<ShelterDetailResponse> getShelterByCareRegNo(
+            @PathVariable String careRegNo
+    ) {
+        ShelterDetailResponse response = shelterFacade.findByCareRegNo(careRegNo);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 보호소 정보 수정 (보호소 회원)
+     * - PUT /api/shelters/{id}
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ShelterDetailResponse> updateShelter(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateShelterRequest request
+    ) {
+        ShelterDetailResponse response = shelterFacade.update(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 보호소 삭제 (관리자)
+     * - DELETE /api/shelters/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteShelter(@PathVariable Long id) {
+        shelterFacade.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 전체 보호소 수 조회
+     * - GET /api/shelters/count
+     */
+    @GetMapping("/count")
+    public ResponseEntity<Long> countShelters() {
+        long count = shelterFacade.countAll();
+        return ResponseEntity.ok(count);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/CreateAnimalRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/CreateAnimalRequest.java
@@ -1,0 +1,149 @@
+package com.pawbridge.animalservice.dto.request;
+
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.ApiSource;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.NeuterStatus;
+import com.pawbridge.animalservice.enums.Species;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 동물 등록 요청 DTO
+ * - 보호소 회원/관리자가 동물을 수동 등록할 때 사용
+ * - APMS 배치는 별도 DTO(ApmsAnimalDto) 사용
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAnimalRequest {
+
+    // 필수 필드 (9개)
+    /**
+     * 보호소 ID
+     */
+    @NotNull(message = "보호소 ID는 필수입니다")
+    private Long shelterId;
+
+    /**
+     * 공고번호
+     * - 예: "경기-양평-2025-00429"
+     * - UNIQUE 제약으로 중복 방지
+     */
+    @NotBlank(message = "공고번호는 필수입니다")
+    @Size(max = 100, message = "공고번호는 100자 이하여야 합니다")
+    private String apmsNoticeNo;
+
+    /**
+     * 공고 시작일
+     */
+    @NotNull(message = "공고 시작일은 필수입니다")
+    private LocalDate noticeStartDate;
+
+    /**
+     * 공고 종료일
+     */
+    @NotNull(message = "공고 종료일은 필수입니다")
+    private LocalDate noticeEndDate;
+
+    /**
+     * 축종 (개/고양이/기타)
+     */
+    @NotNull(message = "축종은 필수입니다")
+    private Species species;
+
+    /**
+     * 성별 (수컷/암컷/미상)
+     */
+    @NotNull(message = "성별은 필수입니다")
+    private Gender gender;
+
+    /**
+     * 중성화 여부 (예/아니오/미상)
+     */
+    @NotNull(message = "중성화 여부는 필수입니다")
+    private NeuterStatus neuterStatus;
+
+    /**
+     * 동물 상태
+     * - NOTICE(공고중), PROTECT(보호중), ADOPTION_PENDING(입양대기), ADOPTED(입양완료) 등
+     */
+    @NotNull(message = "동물 상태는 필수입니다")
+    private AnimalStatus status;
+
+    /**
+     * 데이터 출처
+     * - MANUAL(수동등록), APMS_ANIMAL(APMS API) 등
+     */
+    @NotNull(message = "데이터 출처는 필수입니다")
+    private ApiSource apiSource;
+
+    // 선택 필드 (9개)
+    /**
+     * 품종명
+     * - 예: "믹스견", "라브라도 리트리버"
+     */
+    @Size(max = 100, message = "품종명은 100자 이하여야 합니다")
+    private String breed;
+
+    /**
+     * 출생 연도
+     * - 예: 2023
+     */
+    @Min(value = 1900, message = "출생연도는 1900년 이후여야 합니다")
+    @Max(value = 2100, message = "출생연도는 2100년 이하여야 합니다")
+    private Integer birthYear;
+
+    /**
+     * 체중
+     * - 예: "12(Kg)"
+     */
+    @Size(max = 50, message = "체중은 50자 이하여야 합니다")
+    private String weight;
+
+    /**
+     * 색상
+     * - 예: "옅은 황색", "검정&흰색"
+     */
+    @Size(max = 100, message = "색상은 100자 이하여야 합니다")
+    private String color;
+
+    /**
+     * 특징
+     * - 예: "엄청 까불까불하고 순해요~잘생김~"
+     */
+    @Size(max = 1000, message = "특징은 1000자 이하여야 합니다")
+    private String specialMark;
+
+    /**
+     * 발견 장소
+     * - 예: "진해구 남문동 남문시티 1차"
+     */
+    @Size(max = 200, message = "발견장소는 200자 이하여야 합니다")
+    private String happenPlace;
+
+    /**
+     * 대표 이미지 URL
+     */
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다")
+    private String imageUrl;
+
+    /**
+     * 추가 이미지 URL
+     */
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다")
+    private String imageUrl2;
+
+    /**
+     * 보호소가 추가 작성한 설명
+     * - APMS 데이터 외 보호소가 직접 입력하는 상세 설명
+     */
+    @Size(max = 2000, message = "설명은 2000자 이하여야 합니다")
+    private String description;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/CreateShelterRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/CreateShelterRequest.java
@@ -1,0 +1,96 @@
+package com.pawbridge.animalservice.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 보호소 등록 요청 DTO
+ * - POST /api/shelters
+ * - 관리자가 보호소를 수동 등록할 때 사용
+ * - APMS 배치는 createFromApms() 정적 팩토리 메서드 사용
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateShelterRequest {
+
+    // 필수 필드 (2개)
+    /**
+     * 보호소 등록번호
+     * - 예: "348527200900001"
+     * - UNIQUE 제약
+     */
+    @NotBlank(message = "보호소 등록번호는 필수입니다")
+    @Size(max = 50, message = "보호소 등록번호는 50자 이하여야 합니다")
+    private String careRegNo;
+
+    /**
+     * 보호소 이름
+     * - 예: "창원동물보호센터"
+     */
+    @NotBlank(message = "보호소 이름은 필수입니다")
+    @Size(max = 200, message = "보호소 이름은 200자 이하여야 합니다")
+    private String name;
+
+    // 선택 필드 (APMS 정보)
+    /**
+     * 보호소 전화번호
+     * - 예: "055-225-5701"
+     */
+    @Size(max = 50, message = "전화번호는 50자 이하여야 합니다")
+    private String phone;
+
+    /**
+     * 보호소 주소
+     * - 예: "경상남도 창원시 성산구 공단로474번길 117 (상복동)"
+     */
+    @Size(max = 500, message = "주소는 500자 이하여야 합니다")
+    private String address;
+
+    /**
+     * 보호소 대표자
+     * - 예: "창원시장"
+     */
+    @Size(max = 100, message = "대표자명은 100자 이하여야 합니다")
+    private String ownerName;
+
+    /**
+     * 관할 기관
+     * - 예: "경상남도 창원시 의창성산구"
+     */
+    @Size(max = 200, message = "관할 기관명은 200자 이하여야 합니다")
+    private String organizationName;
+
+    // 선택 필드 (자체 관리)
+    /**
+     * 보호소 이메일
+     */
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @Size(max = 100, message = "이메일은 100자 이하여야 합니다")
+    private String email;
+
+    /**
+     * 보호소 소개
+     */
+    @Size(max = 2000, message = "소개는 2000자 이하여야 합니다")
+    private String introduction;
+
+    /**
+     * 입양 절차 안내
+     */
+    @Size(max = 2000, message = "입양 절차 안내는 2000자 이하여야 합니다")
+    private String adoptionProcedure;
+
+    /**
+     * 운영 시간
+     * - 예: "평일 09:00-18:00, 주말 10:00-17:00"
+     */
+    @Size(max = 200, message = "운영 시간은 200자 이하여야 합니다")
+    private String operatingHours;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateAnimalDescriptionRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateAnimalDescriptionRequest.java
@@ -1,0 +1,28 @@
+package com.pawbridge.animalservice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 동물 설명 수정 요청 DTO
+ * - PATCH /api/animals/{id}/description
+ * - 보호소 회원이 동물에 대한 상세 설명을 추가/수정
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateAnimalDescriptionRequest {
+
+    /**
+     * 새로운 설명
+     * - 보호소가 직접 작성하는 동물에 대한 상세 설명
+     */
+    @NotBlank(message = "설명은 필수입니다")
+    @Size(max = 2000, message = "설명은 2000자 이하여야 합니다")
+    private String description;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateAnimalStatusRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateAnimalStatusRequest.java
@@ -1,0 +1,27 @@
+package com.pawbridge.animalservice.dto.request;
+
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 동물 상태 변경 요청 DTO
+ * - PATCH /api/animals/{id}/status
+ * - 공고중 → 보호중, 입양대기 → 입양완료 등의 상태 변경
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateAnimalStatusRequest {
+
+    /**
+     * 새로운 상태
+     * - NOTICE, PROTECT, ADOPTION_PENDING, ADOPTED, RETURNED_TO_OWNER, EUTHANIZED 등
+     */
+    @NotNull(message = "새로운 상태는 필수입니다")
+    private AnimalStatus newStatus;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateShelterRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateShelterRequest.java
@@ -1,0 +1,55 @@
+package com.pawbridge.animalservice.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 보호소 정보 수정 요청 DTO
+ * - PUT /api/shelters/{id} 또는 PATCH /api/shelters/{id}
+ * - 보호소 회원이 자신의 보호소 정보를 수정할 때 사용
+ * - APMS 기본 정보(careRegNo, name, address, ownerName, organizationName)는 수정 불가
+ * - 보호소가 직접 관리하는 정보만 수정 가능
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateShelterRequest {
+
+    /**
+     * 보호소 전화번호
+     * - 예: "055-225-5701"
+     */
+    @Size(max = 50, message = "전화번호는 50자 이하여야 합니다")
+    private String phone;
+
+    /**
+     * 보호소 이메일
+     */
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @Size(max = 100, message = "이메일은 100자 이하여야 합니다")
+    private String email;
+
+    /**
+     * 보호소 소개
+     */
+    @Size(max = 2000, message = "소개는 2000자 이하여야 합니다")
+    private String introduction;
+
+    /**
+     * 입양 절차 안내
+     */
+    @Size(max = 2000, message = "입양 절차 안내는 2000자 이하여야 합니다")
+    private String adoptionProcedure;
+
+    /**
+     * 운영 시간
+     * - 예: "평일 09:00-18:00, 주말 10:00-17:00"
+     */
+    @Size(max = 200, message = "운영 시간은 200자 이하여야 합니다")
+    private String operatingHours;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/AnimalDetailResponse.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/AnimalDetailResponse.java
@@ -1,0 +1,182 @@
+package com.pawbridge.animalservice.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.ApiSource;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.NeuterStatus;
+import com.pawbridge.animalservice.enums.Species;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 동물 상세 응답 DTO (상세 조회용)
+ * - GET /api/animals/{id} (상세 조회)
+ * - 모든 필드를 포함하여 완전한 정보 제공
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnimalDetailResponse {
+
+    // 기본 정보
+    /**
+     * 동물 ID
+     */
+    private Long id;
+
+    /**
+     * 공고번호
+     */
+    private String apmsNoticeNo;
+
+    /**
+     * 축종
+     */
+    private Species species;
+
+    /**
+     * 품종명
+     */
+    private String breed;
+
+    /**
+     * 성별
+     */
+    private Gender gender;
+
+    /**
+     * 중성화 여부
+     */
+    private NeuterStatus neuterStatus;
+
+    /**
+     * 출생 연도
+     */
+    private Integer birthYear;
+
+    /**
+     * 나이 (계산된 값)
+     */
+    private Integer age;
+
+    // 신체 특징
+    /**
+     * 체중
+     */
+    private String weight;
+
+    /**
+     * 색상
+     */
+    private String color;
+
+    /**
+     * 특징
+     */
+    private String specialMark;
+
+    // 상태 및 공고 정보
+    /**
+     * 동물 상태
+     */
+    private AnimalStatus status;
+
+    /**
+     * 공고 시작일
+     */
+    private LocalDate noticeStartDate;
+
+    /**
+     * 공고 종료일
+     */
+    private LocalDate noticeEndDate;
+
+    // 발견/접수 정보
+    /**
+     * 발견 장소
+     */
+    private String happenPlace;
+
+    /**
+     * 접수일 (APMS 데이터)
+     */
+    private LocalDate happenDate;
+
+    // 이미지
+
+    /**
+     * 대표 이미지 URL
+     */
+    private String imageUrl;
+
+    /**
+     * 추가 이미지 URL
+     */
+    private String imageUrl2;
+
+    // 설명
+    /**
+     * 보호소가 추가 작성한 설명
+     */
+    private String description;
+
+    // 찜 정보
+    /**
+     * 찜 횟수
+     */
+    private Integer favoriteCount;
+
+    // 보호소 정보
+
+    /**
+     * 보호소 ID
+     */
+    private Long shelterId;
+
+    /**
+     * 보호소 이름
+     */
+    private String shelterName;
+
+    // APMS 연동 정보
+
+    /**
+     * APMS 유기번호 (APMS 배치 전용)
+     */
+    private String apmsDesertionNo;
+
+    /**
+     * APMS 처리상태 (APMS 배치 전용)
+     */
+    private String apmsProcessState;
+
+    /**
+     * APMS 마지막 동기화 시간
+     */
+    private LocalDateTime apmsUpdatedAt;
+
+    /**
+     * 데이터 출처
+     */
+    private ApiSource apiSource;
+
+    // 메타 정보
+
+    /**
+     * 등록일
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * 수정일
+     */
+    private LocalDateTime updatedAt;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/AnimalResponse.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/AnimalResponse.java
@@ -1,0 +1,96 @@
+package com.pawbridge.animalservice.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.Species;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 동물 응답 DTO (목록 조회용)
+ * - GET /api/animals (목록 조회)
+ * - 핵심 정보만 포함하여 가볍게 구성
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnimalResponse {
+
+    /**
+     * 동물 ID
+     */
+    private Long id;
+
+    /**
+     * 공고번호
+     */
+    private String apmsNoticeNo;
+
+    /**
+     * 축종
+     */
+    private Species species;
+
+    /**
+     * 품종명
+     */
+    private String breed;
+
+    /**
+     * 성별
+     */
+    private Gender gender;
+
+    /**
+     * 출생 연도
+     */
+    private Integer birthYear;
+
+    /**
+     * 나이 (계산된 값)
+     */
+    private Integer age;
+
+    /**
+     * 동물 상태
+     */
+    private AnimalStatus status;
+
+    /**
+     * 공고 종료일
+     */
+    private LocalDate noticeEndDate;
+
+    /**
+     * 대표 이미지 URL
+     */
+    private String imageUrl;
+
+    /**
+     * 찜 횟수
+     */
+    private Integer favoriteCount;
+
+    /**
+     * 보호소 ID
+     */
+    private Long shelterId;
+
+    /**
+     * 보호소 이름 (간단 표시용)
+     */
+    private String shelterName;
+
+    /**
+     * 등록일
+     */
+    private LocalDateTime createdAt;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/ShelterDetailResponse.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/ShelterDetailResponse.java
@@ -1,0 +1,91 @@
+package com.pawbridge.animalservice.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 보호소 상세 응답 DTO (상세 조회용)
+ * - GET /api/shelters/{id} (상세 조회)
+ * - 모든 필드를 포함하여 완전한 정보 제공
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ShelterDetailResponse {
+
+    // 기본 정보
+    /**
+     * 보호소 ID
+     */
+    private Long id;
+
+    /**
+     * 보호소 등록번호
+     */
+    private String careRegNo;
+
+    /**
+     * 보호소 이름
+     */
+    private String name;
+
+    /**
+     * 보호소 전화번호
+     */
+    private String phone;
+
+    /**
+     * 보호소 주소
+     */
+    private String address;
+
+    /**
+     * 보호소 대표자
+     */
+    private String ownerName;
+
+    /**
+     * 관할 기관
+     */
+    private String organizationName;
+
+    // 자체 관리 정보
+    /**
+     * 보호소 이메일
+     */
+    private String email;
+
+    /**
+     * 보호소 소개
+     */
+    private String introduction;
+
+    /**
+     * 입양 절차 안내
+     */
+    private String adoptionProcedure;
+
+    /**
+     * 운영 시간
+     */
+    private String operatingHours;
+
+    // 메타 정보
+
+    /**
+     * 등록일
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * 수정일
+     */
+    private LocalDateTime updatedAt;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/ShelterResponse.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/ShelterResponse.java
@@ -1,0 +1,57 @@
+package com.pawbridge.animalservice.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 보호소 응답 DTO (목록 조회용)
+ * - GET /api/shelters (목록 조회)
+ * - 핵심 정보만 포함하여 가볍게 구성
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ShelterResponse {
+
+    /**
+     * 보호소 ID
+     */
+    private Long id;
+
+    /**
+     * 보호소 등록번호
+     */
+    private String careRegNo;
+
+    /**
+     * 보호소 이름
+     */
+    private String name;
+
+    /**
+     * 보호소 전화번호
+     */
+    private String phone;
+
+    /**
+     * 보호소 주소
+     */
+    private String address;
+
+    /**
+     * 관할 기관
+     */
+    private String organizationName;
+
+    /**
+     * 등록일
+     */
+    private LocalDateTime createdAt;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/Animal.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/Animal.java
@@ -1,0 +1,396 @@
+package com.pawbridge.animalservice.entity;
+
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.ApiSource;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.NeuterStatus;
+import com.pawbridge.animalservice.enums.Species;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
+
+/**
+ * 유기동물 정보 엔티티
+ * - APMS(동물보호관리시스템) API 응답 데이터를 기반으로 설계
+ * - 실제 API 응답에서 자주 채워지는 필드만 포함 (27개)
+ */
+@Entity
+@Table(name = "animals",
+        indexes = {
+                @Index(name = "idx_apms_desertion_no", columnList = "apmsDesertionNo", unique = true),
+                @Index(name = "idx_species_status", columnList = "species,status"),
+                @Index(name = "idx_notice_end_date", columnList = "noticeEndDate"),
+                @Index(name = "idx_shelter_id", columnList = "shelter_id")
+        })
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Animal {
+
+    // ========== 기본 PK ==========
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // ========== APMS 핵심 식별 (2개) ==========
+    /**
+     * APMS 유기번호 (desertionNo)
+     * - 예: "448567202501701"
+     * - UNIQUE 제약: 중복 체크용
+     */
+    @Column(nullable = false, unique = true, length = 50)
+    private String apmsDesertionNo;
+
+    /**
+     * APMS 공고번호 (noticeNo)
+     * - 예: "경남-창원1-2025-00833"
+     */
+    @Column(nullable = false, length = 100)
+    private String apmsNoticeNo;
+
+    // ========== 동물 기본 정보 (9개) ==========
+    /**
+     * 축종 (upKindCd)
+     * - 417000 → DOG, 422400 → CAT, 429900 → ETC
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Species species;
+
+    /**
+     * 품종명 (kindNm)
+     * - 예: "믹스견", "라브라도 리트리버"
+     */
+    @Column(length = 100)
+    private String breed;
+
+    /**
+     * 출생 연도
+     * - age 필드에서 추출: "2023(년생)" → 2023
+     * - "2025(60일미만)(년생)" → 2025
+     */
+    private Integer birthYear;
+
+    /**
+     * 체중 (weight)
+     * - 예: "12(Kg)", "2.2(Kg)"
+     * - String으로 저장 (단위 포함)
+     */
+    @Column(length = 50)
+    private String weight;
+
+    /**
+     * 색상 (colorCd)
+     * - 예: "옅은 황색", "검정&흰색", "갈색"
+     */
+    @Column(length = 100)
+    private String color;
+
+    /**
+     * 성별 (sexCd)
+     * - M → MALE, F → FEMALE, Q → UNKNOWN
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Gender gender;
+
+    /**
+     * 중성화 여부 (neuterYn)
+     * - Y → YES, N → NO, U → UNKNOWN
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NeuterStatus neuterStatus;
+
+    /**
+     * 특징 (specialMark)
+     * - 예: "엄청 까불까불하고 순해요~잘생김~보호자분도 애타게 찾으실듯..."
+     */
+    @Column(length = 1000)
+    private String specialMark;
+
+    // ========== APMS 공고 정보 (4개) ==========
+    /**
+     * APMS 진행상태 (processState)
+     * - 예: "공고중", "보호중"
+     * - APMS의 원본 상태 (자체 status와 분리)
+     */
+    @Column(length = 50)
+    private String apmsProcessState;
+
+    /**
+     * 공고 시작일 (noticeSdt)
+     * - YYYYMMDD → LocalDate 변환
+     */
+    private LocalDate noticeStartDate;
+
+    /**
+     * 공고 종료일 (noticeEdt)
+     * - YYYYMMDD → LocalDate 변환
+     * - 공고 종료 임박 정렬에 사용
+     */
+    private LocalDate noticeEndDate;
+
+    /**
+     * APMS 마지막 수정 시각 (updTm)
+     * - 예: "2025-11-09 17:34:36.0"
+     * - 동기화 시 변경 감지에 유용
+     */
+    private LocalDateTime apmsUpdatedAt;
+
+    // ========== 발견 정보 (2개) ==========
+    /**
+     * 접수일 (happenDt)
+     * - YYYYMMDD → LocalDate 변환
+     */
+    private LocalDate happenDate;
+
+    /**
+     * 발견 장소 (happenPlace)
+     * - 예: "진해구 남문동 남문시티 1차"
+     */
+    @Column(length = 200)
+    private String happenPlace;
+
+    // ========== 이미지 (2개) ==========
+    /**
+     * 대표 이미지 (popfile1)
+     * - URL 형태
+     */
+    @Column(length = 500)
+    private String imageUrl;
+
+    /**
+     * 추가 이미지 (popfile2)
+     * - 실제 응답에서 거의 항상 포함됨
+     */
+    @Column(length = 500)
+    private String imageUrl2;
+
+    // ========== 보호소 연결 ==========
+    /**
+     * 보호소 FK
+     * - careRegNo로 Shelter 조회 후 연결
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shelter_id", nullable = false)
+    private Shelter shelter;
+
+    // ========== 자체 관리 필드 (4개) ==========
+    /**
+     * 자체 관리 상태 (AnimalStatus)
+     * - NOTICE, PROTECT, ADOPTION_PENDING, ADOPTED 등
+     * - apmsProcessState와 분리 관리
+     * - 예: APMS는 "공고중"이지만 우리 시스템에서는 "입양완료"
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private AnimalStatus status;
+
+    /**
+     * API 출처 (ApiSource)
+     * - APMS_ANIMAL, GYEONGGI, MANUAL 등
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ApiSource apiSource;
+
+    /**
+     * 찜 횟수 (캐시)
+     * - user-service의 favorite 이벤트로 업데이트
+     */
+    @Column(nullable = false)
+    private Integer favoriteCount = 0;
+
+    /**
+     * 보호소가 추가 작성한 설명 (자체)
+     * - APMS 데이터 외 보호소가 직접 입력
+     */
+    @Column(length = 2000)
+    private String description;
+
+    // ========== Audit (2개) ==========
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    // ========== 비즈니스 메서드 ==========
+
+    /**
+     * 상태 변경
+     * @param newStatus 새로운 상태
+     */
+    public void updateStatus(AnimalStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    /**
+     * 찜 횟수 증가
+     */
+    public void incrementFavoriteCount() {
+        this.favoriteCount++;
+    }
+
+    /**
+     * 찜 횟수 감소
+     */
+    public void decrementFavoriteCount() {
+        if (this.favoriteCount > 0) {
+            this.favoriteCount--;
+        }
+    }
+
+    /**
+     * 나이 계산 (현재 연도 기준)
+     * @return 만 나이
+     */
+    public Integer getAge() {
+        if (birthYear == null) return null;
+        return Year.now().getValue() - birthYear;
+    }
+
+    /**
+     * 공고 종료 임박 여부
+     * @return 3일 이내 종료 시 true
+     */
+    public boolean isNoticeExpiringSoon() {
+        if (noticeEndDate == null) return false;
+        return LocalDate.now().plusDays(3).isAfter(noticeEndDate);
+    }
+
+    /**
+     * Shelter 설정
+     * @param shelter 보호소
+     */
+    public void setShelter(Shelter shelter) {
+        this.shelter = shelter;
+    }
+
+    // ========== 정적 팩토리 메서드 ==========
+
+    /**
+     * APMS 데이터로부터 Animal 생성 (기본값 설정)
+     */
+    public static Animal createFromApms(
+            String apmsDesertionNo,
+            String apmsNoticeNo,
+            Species species,
+            Gender gender,
+            NeuterStatus neuterStatus,
+            ApiSource apiSource,
+            Shelter shelter
+    ) {
+        Animal animal = new Animal();
+        animal.apmsDesertionNo = apmsDesertionNo;
+        animal.apmsNoticeNo = apmsNoticeNo;
+        animal.species = species;
+        animal.gender = gender;
+        animal.neuterStatus = neuterStatus;
+        animal.apiSource = apiSource;
+        animal.shelter = shelter;
+        animal.status = AnimalStatus.NOTICE; // 초기 상태
+        animal.favoriteCount = 0;
+        return animal;
+    }
+
+    // ========== Setter 메서드 (ApmsDataMapper에서 사용) ==========
+
+    public void setApmsDesertionNo(String apmsDesertionNo) {
+        this.apmsDesertionNo = apmsDesertionNo;
+    }
+
+    public void setApmsNoticeNo(String apmsNoticeNo) {
+        this.apmsNoticeNo = apmsNoticeNo;
+    }
+
+    public void setSpecies(Species species) {
+        this.species = species;
+    }
+
+    public void setBreed(String breed) {
+        this.breed = breed;
+    }
+
+    public void setBirthYear(Integer birthYear) {
+        this.birthYear = birthYear;
+    }
+
+    public void setWeight(String weight) {
+        this.weight = weight;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public void setGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    public void setNeuterStatus(NeuterStatus neuterStatus) {
+        this.neuterStatus = neuterStatus;
+    }
+
+    public void setSpecialMark(String specialMark) {
+        this.specialMark = specialMark;
+    }
+
+    public void setApmsProcessState(String apmsProcessState) {
+        this.apmsProcessState = apmsProcessState;
+    }
+
+    public void setNoticeStartDate(LocalDate noticeStartDate) {
+        this.noticeStartDate = noticeStartDate;
+    }
+
+    public void setNoticeEndDate(LocalDate noticeEndDate) {
+        this.noticeEndDate = noticeEndDate;
+    }
+
+    public void setApmsUpdatedAt(LocalDateTime apmsUpdatedAt) {
+        this.apmsUpdatedAt = apmsUpdatedAt;
+    }
+
+    public void setHappenDate(LocalDate happenDate) {
+        this.happenDate = happenDate;
+    }
+
+    public void setHappenPlace(String happenPlace) {
+        this.happenPlace = happenPlace;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void setImageUrl2(String imageUrl2) {
+        this.imageUrl2 = imageUrl2;
+    }
+
+    public void setStatus(AnimalStatus status) {
+        this.status = status;
+    }
+
+    public void setApiSource(ApiSource apiSource) {
+        this.apiSource = apiSource;
+    }
+
+    public void setFavoriteCount(Integer favoriteCount) {
+        this.favoriteCount = favoriteCount;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/Animal.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/Animal.java
@@ -45,15 +45,18 @@ public class Animal {
      * APMS 유기번호 (desertionNo)
      * - 예: "448567202501701"
      * - UNIQUE 제약: 중복 체크용
+     * - APMS 배치 전용 (수동 등록 시 null)
      */
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(unique = true, length = 50)
     private String apmsDesertionNo;
 
     /**
-     * APMS 공고번호 (noticeNo)
-     * - 예: "경남-창원1-2025-00833"
+     * 공고번호 (noticeNo)
+     * - 예: "경남-창원1-2025-00833", "경기-양평-2025-00429"
+     * - APMS 배치 + 수동 등록 모두 사용
+     * - UNIQUE 제약: 중복 방지
      */
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, unique = true, length = 100)
     private String apmsNoticeNo;
 
     // ========== 동물 기본 정보 (9개) ==========
@@ -122,6 +125,7 @@ public class Animal {
      * APMS 진행상태 (processState)
      * - 예: "공고중", "보호중"
      * - APMS의 원본 상태 (자체 status와 분리)
+     * - APMS 배치 전용
      */
     @Column(length = 50)
     private String apmsProcessState;
@@ -129,14 +133,18 @@ public class Animal {
     /**
      * 공고 시작일 (noticeSdt)
      * - YYYYMMDD → LocalDate 변환
+     * - APMS 배치 + 수동 등록 모두 사용 (필수)
      */
+    @Column(nullable = false)
     private LocalDate noticeStartDate;
 
     /**
      * 공고 종료일 (noticeEdt)
      * - YYYYMMDD → LocalDate 변환
      * - 공고 종료 임박 정렬에 사용
+     * - APMS 배치 + 수동 등록 모두 사용 (필수)
      */
+    @Column(nullable = false)
     private LocalDate noticeEndDate;
 
     /**

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/BaseTimeEntity.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.pawbridge.animalservice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/Shelter.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/Shelter.java
@@ -1,9 +1,7 @@
 package com.pawbridge.animalservice.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -23,15 +21,17 @@ import java.util.List;
         })
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Shelter {
+public class Shelter extends BaseTimeEntity {
 
-    // ========== 기본 PK ==========
+    // 기본 PK
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // ========== APMS 보호소 식별 ==========
+    // APMS 보호소 식별
     /**
      * 보호소 등록번호 (careRegNo)
      * - 예: "348527200900001"
@@ -41,7 +41,7 @@ public class Shelter {
     @Column(nullable = false, unique = true, length = 50)
     private String careRegNo;
 
-    // ========== 보호소 기본 정보 ==========
+    // 보호소 기본 정보
     /**
      * 보호소 이름 (careNm)
      * - 예: "창원동물보호센터"
@@ -77,7 +77,7 @@ public class Shelter {
     @Column(length = 200)
     private String organizationName;
 
-    // ========== 자체 추가 정보 (보호소 회원이 직접 입력) ==========
+    // 자체 추가 정보 (보호소 회원이 직접 입력)
     /**
      * 보호소 이메일 (자체 관리)
      * - APMS에는 없지만 우리 시스템에서 관리
@@ -104,7 +104,7 @@ public class Shelter {
     @Column(length = 200)
     private String operatingHours;
 
-    // ========== 관계 ==========
+    // 관계
     /**
      * 보호 중인 동물 목록
      * - mappedBy: Animal.shelter 필드와 연결
@@ -112,18 +112,11 @@ public class Shelter {
      * - orphanRemoval = false: Animal에서 shelter 참조 제거해도 Shelter는 유지
      *   (같은 Shelter를 여러 Animal이 참조할 수 있으므로)
      */
+    @Builder.Default
     @OneToMany(mappedBy = "shelter", cascade = CascadeType.PERSIST, orphanRemoval = false)
     private List<Animal> animals = new ArrayList<>();
 
-    // ========== Audit ==========
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
-    // ========== 비즈니스 메서드 ==========
+    // 비즈니스 메서드
 
     /**
      * 동물 추가
@@ -160,7 +153,7 @@ public class Shelter {
         this.operatingHours = operatingHours;
     }
 
-    // ========== 정적 팩토리 메서드 ==========
+    // 정적 팩토리 메서드
 
     /**
      * APMS 데이터로부터 Shelter 생성
@@ -173,55 +166,14 @@ public class Shelter {
             String ownerName,
             String organizationName
     ) {
-        Shelter shelter = new Shelter();
-        shelter.careRegNo = careRegNo;
-        shelter.name = name;
-        shelter.phone = phone;
-        shelter.address = address;
-        shelter.ownerName = ownerName;
-        shelter.organizationName = organizationName;
-        return shelter;
-    }
-
-    // ========== Setter 메서드 (필요 시) ==========
-
-    public void setCareRegNo(String careRegNo) {
-        this.careRegNo = careRegNo;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
-
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
-    public void setOwnerName(String ownerName) {
-        this.ownerName = ownerName;
-    }
-
-    public void setOrganizationName(String organizationName) {
-        this.organizationName = organizationName;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public void setIntroduction(String introduction) {
-        this.introduction = introduction;
-    }
-
-    public void setAdoptionProcedure(String adoptionProcedure) {
-        this.adoptionProcedure = adoptionProcedure;
-    }
-
-    public void setOperatingHours(String operatingHours) {
-        this.operatingHours = operatingHours;
+        return Shelter.builder()
+                .careRegNo(careRegNo)
+                .name(name)
+                .phone(phone)
+                .address(address)
+                .ownerName(ownerName)
+                .organizationName(organizationName)
+                .animals(new ArrayList<>())
+                .build();
     }
 }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/Shelter.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/Shelter.java
@@ -1,0 +1,227 @@
+package com.pawbridge.animalservice.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 보호소 정보 엔티티
+ * - APMS API 응답의 보호소 관련 필드를 기반으로 설계
+ */
+@Entity
+@Table(name = "shelters",
+        indexes = {
+                @Index(name = "idx_care_reg_no", columnList = "careRegNo", unique = true)
+        })
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Shelter {
+
+    // ========== 기본 PK ==========
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // ========== APMS 보호소 식별 ==========
+    /**
+     * 보호소 등록번호 (careRegNo)
+     * - 예: "348527200900001"
+     * - APMS에서 제공하는 보호소 고유 번호
+     * - UNIQUE 제약
+     */
+    @Column(nullable = false, unique = true, length = 50)
+    private String careRegNo;
+
+    // ========== 보호소 기본 정보 ==========
+    /**
+     * 보호소 이름 (careNm)
+     * - 예: "창원동물보호센터"
+     */
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    /**
+     * 보호소 전화번호 (careTel)
+     * - 예: "055-225-5701"
+     */
+    @Column(length = 50)
+    private String phone;
+
+    /**
+     * 보호소 주소 (careAddr)
+     * - 예: "경상남도 창원시 성산구 공단로474번길 117 (상복동) 창원동물보호센터"
+     */
+    @Column(length = 500)
+    private String address;
+
+    /**
+     * 보호소 대표자 (careOwnerNm)
+     * - 예: "창원시장"
+     */
+    @Column(length = 100)
+    private String ownerName;
+
+    /**
+     * 관할 기관 (orgNm)
+     * - 예: "경상남도 창원시 의창성산구"
+     */
+    @Column(length = 200)
+    private String organizationName;
+
+    // ========== 자체 추가 정보 (보호소 회원이 직접 입력) ==========
+    /**
+     * 보호소 이메일 (자체 관리)
+     * - APMS에는 없지만 우리 시스템에서 관리
+     */
+    @Column(length = 100)
+    private String email;
+
+    /**
+     * 보호소 소개 (자체 관리)
+     */
+    @Column(length = 2000)
+    private String introduction;
+
+    /**
+     * 입양 절차 안내 (자체 관리)
+     */
+    @Column(length = 2000)
+    private String adoptionProcedure;
+
+    /**
+     * 운영 시간 (자체 관리)
+     * - 예: "평일 09:00-18:00, 주말 10:00-17:00"
+     */
+    @Column(length = 200)
+    private String operatingHours;
+
+    // ========== 관계 ==========
+    /**
+     * 보호 중인 동물 목록
+     * - mappedBy: Animal.shelter 필드와 연결
+     * - cascade = PERSIST: Animal 저장 시 새로운 Shelter도 함께 저장 (배치 작업에서 유용)
+     * - orphanRemoval = false: Animal에서 shelter 참조 제거해도 Shelter는 유지
+     *   (같은 Shelter를 여러 Animal이 참조할 수 있으므로)
+     */
+    @OneToMany(mappedBy = "shelter", cascade = CascadeType.PERSIST, orphanRemoval = false)
+    private List<Animal> animals = new ArrayList<>();
+
+    // ========== Audit ==========
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    // ========== 비즈니스 메서드 ==========
+
+    /**
+     * 동물 추가
+     * @param animal 동물
+     */
+    public void addAnimal(Animal animal) {
+        this.animals.add(animal);
+        animal.setShelter(this);
+    }
+
+    /**
+     * 동물 제거
+     * @param animal 동물
+     */
+    public void removeAnimal(Animal animal) {
+        this.animals.remove(animal);
+        animal.setShelter(null);
+    }
+
+    /**
+     * 보호소 정보 수정 (보호소 회원이 직접 수정)
+     */
+    public void updateInfo(
+            String phone,
+            String email,
+            String introduction,
+            String adoptionProcedure,
+            String operatingHours
+    ) {
+        this.phone = phone;
+        this.email = email;
+        this.introduction = introduction;
+        this.adoptionProcedure = adoptionProcedure;
+        this.operatingHours = operatingHours;
+    }
+
+    // ========== 정적 팩토리 메서드 ==========
+
+    /**
+     * APMS 데이터로부터 Shelter 생성
+     */
+    public static Shelter createFromApms(
+            String careRegNo,
+            String name,
+            String phone,
+            String address,
+            String ownerName,
+            String organizationName
+    ) {
+        Shelter shelter = new Shelter();
+        shelter.careRegNo = careRegNo;
+        shelter.name = name;
+        shelter.phone = phone;
+        shelter.address = address;
+        shelter.ownerName = ownerName;
+        shelter.organizationName = organizationName;
+        return shelter;
+    }
+
+    // ========== Setter 메서드 (필요 시) ==========
+
+    public void setCareRegNo(String careRegNo) {
+        this.careRegNo = careRegNo;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setIntroduction(String introduction) {
+        this.introduction = introduction;
+    }
+
+    public void setAdoptionProcedure(String adoptionProcedure) {
+        this.adoptionProcedure = adoptionProcedure;
+    }
+
+    public void setOperatingHours(String operatingHours) {
+        this.operatingHours = operatingHours;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/AnimalStatus.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/AnimalStatus.java
@@ -1,0 +1,34 @@
+package com.pawbridge.animalservice.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum AnimalStatus {
+    NOTICE("공고중"),
+    PROTECT("보호중"),
+    ADOPTION_PENDING("입양대기중"),    //입양 절차 진행 중
+    ADOPTED("입양완료"),
+    EUTHANIZED("안락사"),
+    NATURAL_DEATH("자연사"),
+    RETURNED("반환"),                 // 주인에게 반환
+    ESCAPED("탈출"),                  // 탈출
+    UNKNOWN("미상");
+
+    private final String description;
+
+    public static AnimalStatus fromCode(String code) {
+        if (code == null) {
+            return NOTICE;
+        }
+
+        for (AnimalStatus animalStatus : AnimalStatus.values()) {
+            if (animalStatus.getDescription().equals(code)) {
+                return animalStatus;
+            }
+        }
+
+        return UNKNOWN;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/ApiSource.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/ApiSource.java
@@ -1,0 +1,29 @@
+package com.pawbridge.animalservice.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ApiSource {
+    APMS_ANIMAL("APMS 구조동물 API"),
+    GYEONGGI("경기도 유기동물 API"),
+    MANUAL("수동 입력"),
+    UNKNOWN("출처 미상");
+
+    private final String description;
+
+    public static ApiSource fromCode(String code) {
+        if (code == null) {
+            return UNKNOWN;
+        }
+
+        for (ApiSource apiSource : ApiSource.values()) {
+            if (apiSource.getDescription().equals(code)) {
+                return apiSource;
+            }
+        }
+
+        return UNKNOWN;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/Gender.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/Gender.java
@@ -1,0 +1,29 @@
+package com.pawbridge.animalservice.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Gender {
+    MALE("M", "수컷"),
+    FEMALE("F", "암컷"),
+    UNKNOWN("Q", "미상");
+
+    private final String code;
+    private final String description;
+
+    public static Gender fromCode(String code) {
+        if (code == null) {
+            return UNKNOWN;
+        }
+
+        for (Gender gender : Gender.values()) {
+            if (gender.getCode().equals(code)) {
+                return gender;
+            }
+        }
+
+        return UNKNOWN;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/NeuterStatus.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/NeuterStatus.java
@@ -1,0 +1,29 @@
+package com.pawbridge.animalservice.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum NeuterStatus {
+    YES("Y", "중성화"),
+    NO("N", "비중성화"),
+    UNKNOWN("U", "미상");
+
+    private final String code;
+    private final String description;
+
+    public static NeuterStatus fromCode(String code) {
+        if (code == null) {
+            return UNKNOWN;
+        }
+
+        for (NeuterStatus neuterStatus : NeuterStatus.values()) {
+            if (neuterStatus.getCode().equals(code)) {
+                return neuterStatus;
+            }
+        }
+
+        return UNKNOWN;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/ProcessStatus.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/ProcessStatus.java
@@ -1,0 +1,18 @@
+package com.pawbridge.animalservice.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * RawApmsData 처리 상태
+ * - APMS API 응답의 파싱 처리 상태를 추적
+ */
+@RequiredArgsConstructor
+@Getter
+public enum ProcessStatus {
+    PENDING("처리 대기"),      // 수집 완료, 파싱 전
+    PROCESSED("처리 완료"),    // 파싱 성공, Animal 엔티티 저장 완료
+    FAILED("처리 실패");       // 파싱 실패 (errorMessage 참고)
+
+    private final String description;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/Species.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/Species.java
@@ -1,0 +1,29 @@
+package com.pawbridge.animalservice.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Species {
+    DOG("417000", "개"),
+    CAT("422400", "고양이"),
+    ETC("429900", "기타");
+
+    private final String code;
+    private final String description;
+
+    public static Species fromCode(String code) {
+        if (code == null) {
+            return ETC;
+        }
+
+        for (Species species : Species.values()) {
+            if (species.getCode().equals(code)) {
+                return species;
+            }
+        }
+
+        return ETC;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/exception/AnimalNotFoundException.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/exception/AnimalNotFoundException.java
@@ -1,0 +1,13 @@
+package com.pawbridge.animalservice.exception;
+
+/**
+ * 동물을 찾을 수 없을 때 발생하는 예외
+ */
+public class AnimalNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.ANIMAL_NOT_FOUND;
+
+    public AnimalNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/exception/ApplicationException.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/exception/ApplicationException.java
@@ -1,0 +1,27 @@
+package com.pawbridge.animalservice.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected ApplicationException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    protected ApplicationException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        if (super.getMessage() == null) {
+            return errorCode.getMessage();
+        }
+
+        return super.getMessage();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/exception/ErrorCode.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/exception/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.pawbridge.animalservice.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 애플리케이션 에러 코드 정의
+ * - 모든 커스텀 예외의 에러 코드를 중앙에서 관리
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Animal 관련 에러 (404)
+    ANIMAL_NOT_FOUND("ANIMAL_NOT_FOUND", "동물을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
+    // Shelter 관련 에러 (404)
+    SHELTER_NOT_FOUND("SHELTER_NOT_FOUND", "보호소를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
+    // Validation 에러 (400)
+    INVALID_INPUT_VALUE("INVALID_INPUT_VALUE", "입력값이 올바르지 않습니다", HttpStatus.BAD_REQUEST),
+    INVALID_ARGUMENT("INVALID_ARGUMENT", "잘못된 인자가 전달되었습니다", HttpStatus.BAD_REQUEST),
+
+    // 권한 에러 (403)
+    PERMISSION_DENIED("PERMISSION_DENIED", "접근 권한이 없습니다", HttpStatus.FORBIDDEN),
+
+    // 서버 에러 (500)
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/exception/GlobalExceptionHandler.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,191 @@
+package com.pawbridge.animalservice.exception;
+
+import com.pawbridge.animalservice.util.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 전역 예외 처리 핸들러
+ * - @RestControllerAdvice로 모든 컨트롤러의 예외를 중앙에서 처리
+ * - 일관된 에러 응답 형식 제공 (ResponseDto)
+ */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * ApplicationException 처리
+     * - 모든 커스텀 예외를 하나의 핸들러로 처리
+     * - ErrorCode에서 HTTP 상태와 에러 메시지 추출
+     */
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ResponseDto<Void>> handleApplicationException(ApplicationException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+
+        log.warn("Application exception occurred: code={}, message={}",
+                errorCode.getCode(), ex.getMessage());
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ResponseDto.errorWithMessage(errorCode.getHttpStatus(), ex.getMessage()));
+    }
+
+    /**
+     * MethodArgumentNotValidException 처리
+     * - @Valid 검증 실패 시 400 반환
+     * - 필드별 에러 메시지 수집
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+
+        List<String> fieldErrors = bindingResult.getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        String errorMessage = String.join(", ", fieldErrors);
+        log.warn("Validation error: {}", errorMessage);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.errorWithMessage(HttpStatus.BAD_REQUEST, errorMessage));
+    }
+
+    /**
+     * BindException 처리
+     * - 데이터 바인딩 실패 시 400 반환
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ResponseDto<Void>> handleBindException(BindException ex) {
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        log.warn("Bind error: {}", errorMessage);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.errorWithMessage(HttpStatus.BAD_REQUEST, errorMessage));
+    }
+
+    /**
+     * IllegalArgumentException 처리
+     * - 잘못된 인자 전달 시 400 반환
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ResponseDto<Void>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("Illegal argument: {}", ex.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.errorWithMessage(HttpStatus.BAD_REQUEST, ex.getMessage()));
+    }
+
+    /**
+     * NoHandlerFoundException 처리
+     * - 존재하지 않는 API 엔드포인트 요청 시 404 반환
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ResponseDto<Void>> handleNoHandlerFoundException(NoHandlerFoundException ex) {
+        log.warn("No handler found for {} {}", ex.getHttpMethod(), ex.getRequestURL());
+
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ResponseDto.errorWithMessage(HttpStatus.NOT_FOUND, "유효하지 않은 엔드포인트입니다."));
+    }
+
+    /**
+     * HttpMessageNotReadableException 처리
+     * - 요청 본문 형식이 올바르지 않을 때 400 반환
+     * - 예: JSON 파싱 오류, 잘못된 형식의 요청 데이터
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseDto<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        log.warn("Bad request body: {}", ex.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.errorWithMessage(HttpStatus.BAD_REQUEST, "요청 본문 형식이 올바르지 않습니다."));
+    }
+
+    /**
+     * HttpRequestMethodNotSupportedException 처리
+     * - 지원되지 않는 HTTP 메소드 요청 시 405 반환
+     * - 예: GET만 허용되는 곳에 POST 요청
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ResponseDto<Void>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
+        log.warn("Method not allowed: {}", ex.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(ResponseDto.errorWithMessage(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메소드입니다."));
+    }
+
+    /**
+     * MissingServletRequestParameterException 처리
+     * - 필수 요청 파라미터 누락 시 400 반환
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ResponseDto<Void>> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
+        String errorMessage = String.format("필수 요청 파라미터 '%s'(이)가 누락되었습니다.", ex.getParameterName());
+        log.warn("Missing request parameter: {}", errorMessage);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.errorWithMessage(HttpStatus.BAD_REQUEST, errorMessage));
+    }
+
+    /**
+     * TypeMismatchException 처리
+     * - 요청 파라미터 타입 불일치 시 400 반환
+     * - 예: 숫자 타입이어야 하는데 문자열 전달
+     */
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<ResponseDto<Void>> handleTypeMismatchException(TypeMismatchException ex) {
+        log.warn("Type mismatch: {}", ex.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResponseDto.errorWithMessage(HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 올바르지 않습니다."));
+    }
+
+    /**
+     * DataAccessException 처리
+     * - 데이터베이스 관련 예외 발생 시 500 반환
+     */
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ResponseDto<Void>> handleDataAccessException(DataAccessException ex) {
+        log.error("Database error: {}", ex.getMessage(), ex);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDto.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 오류가 발생했습니다."));
+    }
+
+    /**
+     * Exception 처리
+     * - 처리되지 않은 모든 예외는 500 반환
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto<Void>> handleException(Exception ex) {
+        log.error("Unexpected error occurred: {}", ex.getMessage(), ex);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseDto.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/exception/ShelterNotFoundException.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/exception/ShelterNotFoundException.java
@@ -1,0 +1,13 @@
+package com.pawbridge.animalservice.exception;
+
+/**
+ * 보호소를 찾을 수 없을 때 발생하는 예외
+ */
+public class ShelterNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.SHELTER_NOT_FOUND;
+
+    public ShelterNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/facade/AnimalFacade.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/facade/AnimalFacade.java
@@ -1,0 +1,316 @@
+package com.pawbridge.animalservice.facade;
+
+import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.Species;
+import com.pawbridge.animalservice.service.AnimalCommandService;
+import com.pawbridge.animalservice.service.AnimalQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Animal Facade
+ * - Command + Query 통합
+ * - Controller의 단일 진입점
+ * - CQRS 내부 구조를 외부로부터 숨김
+ */
+@Service
+@RequiredArgsConstructor
+public class AnimalFacade {
+
+    private final AnimalCommandService commandService;
+    private final AnimalQueryService queryService;
+
+    // ========== Command 위임 (CUD) ==========
+
+    /**
+     * 동물 생성
+     */
+    @Transactional
+    public Animal create(Animal animal) {
+        return commandService.create(animal);
+    }
+
+    /**
+     * 동물 상태 변경
+     */
+    @Transactional
+    public Animal updateStatus(Long id, AnimalStatus newStatus) {
+        return commandService.updateStatus(id, newStatus);
+    }
+
+    /**
+     * 보호소 설명 수정
+     */
+    @Transactional
+    public Animal updateDescription(Long id, String description) {
+        return commandService.updateDescription(id, description);
+    }
+
+    /**
+     * 찜 횟수 증가
+     */
+    @Transactional
+    public void incrementFavoriteCount(Long id) {
+        commandService.incrementFavoriteCount(id);
+    }
+
+    /**
+     * 찜 횟수 감소
+     */
+    @Transactional
+    public void decrementFavoriteCount(Long id) {
+        commandService.decrementFavoriteCount(id);
+    }
+
+    /**
+     * 동물 삭제
+     */
+    @Transactional
+    public void delete(Long id) {
+        commandService.delete(id);
+    }
+
+    /**
+     * APMS 데이터로부터 동물 생성 (배치 전용)
+     */
+    @Transactional
+    public Animal createFromApms(Animal animal) {
+        return commandService.createFromApms(animal);
+    }
+
+    /**
+     * 공고 종료된 동물 상태 일괄 업데이트 (배치)
+     */
+    @Transactional
+    public int updateExpiredNoticeAnimals() {
+        return commandService.updateExpiredNoticeAnimals();
+    }
+
+    // ========== Query 위임 (R) ==========
+
+    /**
+     * ID로 동물 조회 (Shelter 없음)
+     */
+    @Transactional(readOnly = true)
+    public Animal findById(Long id) {
+        return queryService.findById(id);
+    }
+
+    /**
+     * ID로 동물 조회 (Shelter 포함)
+     */
+    @Transactional(readOnly = true)
+    public Animal findByIdWithShelter(Long id) {
+        return queryService.findByIdWithShelter(id);
+    }
+
+    /**
+     * APMS 유기번호로 조회
+     */
+    @Transactional(readOnly = true)
+    public Animal findByApmsDesertionNo(String apmsDesertionNo) {
+        return queryService.findByApmsDesertionNo(apmsDesertionNo);
+    }
+
+    /**
+     * APMS 유기번호로 조회 (Shelter 포함)
+     */
+    @Transactional(readOnly = true)
+    public Animal findByApmsDesertionNoWithShelter(String apmsDesertionNo) {
+        return queryService.findByApmsDesertionNoWithShelter(apmsDesertionNo);
+    }
+
+    /**
+     * 축종별 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findBySpecies(Species species, Pageable pageable) {
+        return queryService.findBySpecies(species, pageable);
+    }
+
+    /**
+     * 상태별 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByStatus(AnimalStatus status, Pageable pageable) {
+        return queryService.findByStatus(status, pageable);
+    }
+
+    /**
+     * 축종 + 성별 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findBySpeciesAndGender(Species species, Gender gender, Pageable pageable) {
+        return queryService.findBySpeciesAndGender(species, gender, pageable);
+    }
+
+    /**
+     * 축종 + 상태 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findBySpeciesAndStatus(Species species, AnimalStatus status, Pageable pageable) {
+        return queryService.findBySpeciesAndStatus(species, status, pageable);
+    }
+
+    /**
+     * 여러 상태 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByStatusIn(List<AnimalStatus> statuses, Pageable pageable) {
+        return queryService.findByStatusIn(statuses, pageable);
+    }
+
+    /**
+     * 축종 + 상태 조회 (Shelter 포함)
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findBySpeciesAndStatusWithShelter(Species species, AnimalStatus status, Pageable pageable) {
+        return queryService.findBySpeciesAndStatusWithShelter(species, status, pageable);
+    }
+
+    /**
+     * 공고 중인 동물 (공고 종료일 임박 순)
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findNoticeAnimalsOrderByNoticeEndDate(Pageable pageable) {
+        return queryService.findNoticeAnimalsOrderByNoticeEndDate(pageable);
+    }
+
+    /**
+     * 공고 종료 임박 동물 (D-3 이내)
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findExpiringSoonAnimals(Pageable pageable) {
+        return queryService.findExpiringSoonAnimals(pageable);
+    }
+
+    /**
+     * 공고 종료일 범위 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByNoticeEndDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable) {
+        return queryService.findByNoticeEndDateBetween(startDate, endDate, pageable);
+    }
+
+    /**
+     * 출생 연도 범위 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByBirthYearBetween(Integer startYear, Integer endYear, Pageable pageable) {
+        return queryService.findByBirthYearBetween(startYear, endYear, pageable);
+    }
+
+    /**
+     * 축종 + 출생 연도 범위 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findBySpeciesAndBirthYearBetween(
+            Species species, Integer startYear, Integer endYear, Pageable pageable) {
+        return queryService.findBySpeciesAndBirthYearBetween(species, startYear, endYear, pageable);
+    }
+
+    /**
+     * 품종명 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> searchByBreed(String breed, Pageable pageable) {
+        return queryService.searchByBreed(breed, pageable);
+    }
+
+    /**
+     * 특징 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> searchBySpecialMark(String keyword, Pageable pageable) {
+        return queryService.searchBySpecialMark(keyword, pageable);
+    }
+
+    /**
+     * 발견 장소 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> searchByHappenPlace(String place, Pageable pageable) {
+        return queryService.searchByHappenPlace(place, pageable);
+    }
+
+    /**
+     * 축종 + 품종 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> searchBySpeciesAndBreed(Species species, String breed, Pageable pageable) {
+        return queryService.searchBySpeciesAndBreed(species, breed, pageable);
+    }
+
+    /**
+     * 보호소 ID로 동물 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByShelterId(Long shelterId, Pageable pageable) {
+        return queryService.findByShelterId(shelterId, pageable);
+    }
+
+    /**
+     * 보호소 ID + 축종 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByShelterIdAndSpecies(Long shelterId, Species species, Pageable pageable) {
+        return queryService.findByShelterIdAndSpecies(shelterId, species, pageable);
+    }
+
+    /**
+     * 보호소 ID + 상태 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Animal> findByShelterIdAndStatus(Long shelterId, AnimalStatus status, Pageable pageable) {
+        return queryService.findByShelterIdAndStatus(shelterId, status, pageable);
+    }
+
+    /**
+     * 축종별 카운트
+     */
+    @Transactional(readOnly = true)
+    public long countBySpecies(Species species) {
+        return queryService.countBySpecies(species);
+    }
+
+    /**
+     * 상태별 카운트
+     */
+    @Transactional(readOnly = true)
+    public long countByStatus(AnimalStatus status) {
+        return queryService.countByStatus(status);
+    }
+
+    /**
+     * 보호소별 카운트
+     */
+    @Transactional(readOnly = true)
+    public long countByShelterId(Long shelterId) {
+        return queryService.countByShelterId(shelterId);
+    }
+
+    /**
+     * 축종 + 상태별 카운트
+     */
+    @Transactional(readOnly = true)
+    public long countBySpeciesAndStatus(Species species, AnimalStatus status) {
+        return queryService.countBySpeciesAndStatus(species, status);
+    }
+
+    /**
+     * APMS 수정 이후 동물 조회 (배치)
+     */
+    @Transactional(readOnly = true)
+    public List<Animal> findByApmsUpdatedAtAfter(LocalDateTime dateTime) {
+        return queryService.findByApmsUpdatedAtAfter(dateTime);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/facade/ShelterFacade.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/facade/ShelterFacade.java
@@ -1,0 +1,135 @@
+package com.pawbridge.animalservice.facade;
+
+import com.pawbridge.animalservice.entity.Shelter;
+import com.pawbridge.animalservice.service.ShelterCommandService;
+import com.pawbridge.animalservice.service.ShelterQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Shelter Facade
+ * - Command + Query 통합
+ * - Controller의 단일 진입점
+ * - CQRS 내부 구조를 외부로부터 숨김
+ */
+@Service
+@RequiredArgsConstructor
+public class ShelterFacade {
+
+    private final ShelterCommandService commandService;
+    private final ShelterQueryService queryService;
+
+    // ========== Command 위임 (CUD) ==========
+
+    /**
+     * 보호소 생성
+     */
+    @Transactional
+    public Shelter create(Shelter shelter) {
+        return commandService.create(shelter);
+    }
+
+    /**
+     * APMS 데이터로부터 보호소 생성 (배치 전용)
+     */
+    @Transactional
+    public Shelter createFromApms(Shelter shelter) {
+        return commandService.createFromApms(shelter);
+    }
+
+    /**
+     * 보호소 정보 수정
+     */
+    @Transactional
+    public Shelter update(Long id, String phone, String email,
+                         String introduction, String adoptionProcedure, String operatingHours) {
+        return commandService.update(id, phone, email, introduction, adoptionProcedure, operatingHours);
+    }
+
+    /**
+     * 보호소 삭제
+     */
+    @Transactional
+    public void delete(Long id) {
+        commandService.delete(id);
+    }
+
+    // ========== Query 위임 (R) ==========
+
+    /**
+     * ID로 보호소 조회
+     */
+    @Transactional(readOnly = true)
+    public Shelter findById(Long id) {
+        return queryService.findById(id);
+    }
+
+    /**
+     * APMS 보호소 등록번호로 조회
+     */
+    @Transactional(readOnly = true)
+    public Shelter findByCareRegNo(String careRegNo) {
+        return queryService.findByCareRegNo(careRegNo);
+    }
+
+    /**
+     * 전체 보호소 조회
+     */
+    @Transactional(readOnly = true)
+    public Page<Shelter> findAll(Pageable pageable) {
+        return queryService.findAll(pageable);
+    }
+
+    /**
+     * 보호소 이름으로 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Shelter> searchByName(String name, Pageable pageable) {
+        return queryService.searchByName(name, pageable);
+    }
+
+    /**
+     * 보호소 주소로 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Shelter> searchByAddress(String address, Pageable pageable) {
+        return queryService.searchByAddress(address, pageable);
+    }
+
+    /**
+     * 관할 기관으로 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Shelter> searchByOrganizationName(String organizationName, Pageable pageable) {
+        return queryService.searchByOrganizationName(organizationName, pageable);
+    }
+
+    /**
+     * 이름 또는 주소로 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<Shelter> searchByNameOrAddress(String keyword, Pageable pageable) {
+        return queryService.searchByNameOrAddress(keyword, pageable);
+    }
+
+    /**
+     * 여러 개의 careRegNo로 Shelter 조회 (배치)
+     */
+    @Transactional(readOnly = true)
+    public List<Shelter> findByCareRegNoIn(List<String> careRegNos) {
+        return queryService.findByCareRegNoIn(careRegNos);
+    }
+
+    /**
+     * 전체 보호소 수 카운트
+     */
+    @Transactional(readOnly = true)
+    public long countAll() {
+        return queryService.countAll();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/facade/ShelterFacade.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/facade/ShelterFacade.java
@@ -1,5 +1,9 @@
 package com.pawbridge.animalservice.facade;
 
+import com.pawbridge.animalservice.dto.request.CreateShelterRequest;
+import com.pawbridge.animalservice.dto.request.UpdateShelterRequest;
+import com.pawbridge.animalservice.dto.response.ShelterDetailResponse;
+import com.pawbridge.animalservice.dto.response.ShelterResponse;
 import com.pawbridge.animalservice.entity.Shelter;
 import com.pawbridge.animalservice.service.ShelterCommandService;
 import com.pawbridge.animalservice.service.ShelterQueryService;
@@ -16,6 +20,7 @@ import java.util.List;
  * - Command + Query 통합
  * - Controller의 단일 진입점
  * - CQRS 내부 구조를 외부로부터 숨김
+ * - DTO 기반 처리
  */
 @Service
 @RequiredArgsConstructor
@@ -24,18 +29,17 @@ public class ShelterFacade {
     private final ShelterCommandService commandService;
     private final ShelterQueryService queryService;
 
-    // ========== Command 위임 (CUD) ==========
-
     /**
      * 보호소 생성
      */
     @Transactional
-    public Shelter create(Shelter shelter) {
-        return commandService.create(shelter);
+    public ShelterDetailResponse create(CreateShelterRequest request) {
+        return commandService.create(request);
     }
 
     /**
      * APMS 데이터로부터 보호소 생성 (배치 전용)
+     * - Entity를 직접 받음 (ApmsShelterMapper에서 생성)
      */
     @Transactional
     public Shelter createFromApms(Shelter shelter) {
@@ -46,9 +50,8 @@ public class ShelterFacade {
      * 보호소 정보 수정
      */
     @Transactional
-    public Shelter update(Long id, String phone, String email,
-                         String introduction, String adoptionProcedure, String operatingHours) {
-        return commandService.update(id, phone, email, introduction, adoptionProcedure, operatingHours);
+    public ShelterDetailResponse update(Long id, UpdateShelterRequest request) {
+        return commandService.update(id, request);
     }
 
     /**
@@ -59,13 +62,11 @@ public class ShelterFacade {
         commandService.delete(id);
     }
 
-    // ========== Query 위임 (R) ==========
-
     /**
-     * ID로 보호소 조회
+     * ID로 보호소 상세 조회
      */
     @Transactional(readOnly = true)
-    public Shelter findById(Long id) {
+    public ShelterDetailResponse findById(Long id) {
         return queryService.findById(id);
     }
 
@@ -73,7 +74,7 @@ public class ShelterFacade {
      * APMS 보호소 등록번호로 조회
      */
     @Transactional(readOnly = true)
-    public Shelter findByCareRegNo(String careRegNo) {
+    public ShelterDetailResponse findByCareRegNo(String careRegNo) {
         return queryService.findByCareRegNo(careRegNo);
     }
 
@@ -81,7 +82,7 @@ public class ShelterFacade {
      * 전체 보호소 조회
      */
     @Transactional(readOnly = true)
-    public Page<Shelter> findAll(Pageable pageable) {
+    public Page<ShelterResponse> findAll(Pageable pageable) {
         return queryService.findAll(pageable);
     }
 
@@ -89,7 +90,7 @@ public class ShelterFacade {
      * 보호소 이름으로 검색
      */
     @Transactional(readOnly = true)
-    public Page<Shelter> searchByName(String name, Pageable pageable) {
+    public Page<ShelterResponse> searchByName(String name, Pageable pageable) {
         return queryService.searchByName(name, pageable);
     }
 
@@ -97,7 +98,7 @@ public class ShelterFacade {
      * 보호소 주소로 검색
      */
     @Transactional(readOnly = true)
-    public Page<Shelter> searchByAddress(String address, Pageable pageable) {
+    public Page<ShelterResponse> searchByAddress(String address, Pageable pageable) {
         return queryService.searchByAddress(address, pageable);
     }
 
@@ -105,7 +106,7 @@ public class ShelterFacade {
      * 관할 기관으로 검색
      */
     @Transactional(readOnly = true)
-    public Page<Shelter> searchByOrganizationName(String organizationName, Pageable pageable) {
+    public Page<ShelterResponse> searchByOrganizationName(String organizationName, Pageable pageable) {
         return queryService.searchByOrganizationName(organizationName, pageable);
     }
 
@@ -113,12 +114,13 @@ public class ShelterFacade {
      * 이름 또는 주소로 검색
      */
     @Transactional(readOnly = true)
-    public Page<Shelter> searchByNameOrAddress(String keyword, Pageable pageable) {
+    public Page<ShelterResponse> searchByNameOrAddress(String keyword, Pageable pageable) {
         return queryService.searchByNameOrAddress(keyword, pageable);
     }
 
     /**
      * 여러 개의 careRegNo로 Shelter 조회 (배치)
+     * - Entity 반환 (배치 작업에서 사용)
      */
     @Transactional(readOnly = true)
     public List<Shelter> findByCareRegNoIn(List<String> careRegNos) {

--- a/animal-service/src/main/java/com/pawbridge/animalservice/mapper/AnimalMapper.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/mapper/AnimalMapper.java
@@ -1,0 +1,125 @@
+package com.pawbridge.animalservice.mapper;
+
+import com.pawbridge.animalservice.dto.request.CreateAnimalRequest;
+import com.pawbridge.animalservice.dto.response.AnimalDetailResponse;
+import com.pawbridge.animalservice.dto.response.AnimalResponse;
+import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.entity.Shelter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * Animal Entity ↔ DTO 변환 매퍼
+ */
+@Component
+public class AnimalMapper {
+
+    // Request DTO → Entity
+    /**
+     * CreateAnimalRequest → Animal Entity
+     * - Shelter는 별도로 설정 필요
+     * @param request 요청 DTO
+     * @param shelter 보호소 엔티티
+     * @return Animal 엔티티
+     */
+    public Animal toEntity(CreateAnimalRequest request, Shelter shelter) {
+        return Animal.builder()
+                .apmsNoticeNo(request.getApmsNoticeNo())
+                .noticeStartDate(request.getNoticeStartDate())
+                .noticeEndDate(request.getNoticeEndDate())
+                .species(request.getSpecies())
+                .breed(request.getBreed())
+                .gender(request.getGender())
+                .neuterStatus(request.getNeuterStatus())
+                .birthYear(request.getBirthYear())
+                .weight(request.getWeight())
+                .color(request.getColor())
+                .specialMark(request.getSpecialMark())
+                .happenPlace(request.getHappenPlace())
+                .imageUrl(request.getImageUrl())
+                .imageUrl2(request.getImageUrl2())
+                .description(request.getDescription())
+                .status(request.getStatus())
+                .apiSource(request.getApiSource())
+                .shelter(shelter)
+                .build();
+    }
+
+    //Entity → Response DTO
+    /**
+     * Animal Entity → AnimalResponse (목록 조회용)
+     * @param animal 동물 엔티티
+     * @return AnimalResponse DTO
+     */
+    public AnimalResponse toResponse(Animal animal) {
+        return AnimalResponse.builder()
+                .id(animal.getId())
+                .apmsNoticeNo(animal.getApmsNoticeNo())
+                .species(animal.getSpecies())
+                .breed(animal.getBreed())
+                .gender(animal.getGender())
+                .birthYear(animal.getBirthYear())
+                .age(calculateAge(animal.getBirthYear()))
+                .status(animal.getStatus())
+                .noticeEndDate(animal.getNoticeEndDate())
+                .imageUrl(animal.getImageUrl())
+                .favoriteCount(animal.getFavoriteCount())
+                .shelterId(animal.getShelter() != null ? animal.getShelter().getId() : null)
+                .shelterName(animal.getShelter() != null ? animal.getShelter().getName() : null)
+                .createdAt(animal.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * Animal Entity → AnimalDetailResponse (상세 조회용)
+     * @param animal 동물 엔티티
+     * @return AnimalDetailResponse DTO
+     */
+    public AnimalDetailResponse toDetailResponse(Animal animal) {
+        return AnimalDetailResponse.builder()
+                .id(animal.getId())
+                .apmsNoticeNo(animal.getApmsNoticeNo())
+                .species(animal.getSpecies())
+                .breed(animal.getBreed())
+                .gender(animal.getGender())
+                .neuterStatus(animal.getNeuterStatus())
+                .birthYear(animal.getBirthYear())
+                .age(calculateAge(animal.getBirthYear()))
+                .weight(animal.getWeight())
+                .color(animal.getColor())
+                .specialMark(animal.getSpecialMark())
+                .status(animal.getStatus())
+                .noticeStartDate(animal.getNoticeStartDate())
+                .noticeEndDate(animal.getNoticeEndDate())
+                .happenPlace(animal.getHappenPlace())
+                .happenDate(animal.getHappenDate())
+                .imageUrl(animal.getImageUrl())
+                .imageUrl2(animal.getImageUrl2())
+                .description(animal.getDescription())
+                .favoriteCount(animal.getFavoriteCount())
+                .shelterId(animal.getShelter() != null ? animal.getShelter().getId() : null)
+                .shelterName(animal.getShelter() != null ? animal.getShelter().getName() : null)
+                .apmsDesertionNo(animal.getApmsDesertionNo())
+                .apmsProcessState(animal.getApmsProcessState())
+                .apmsUpdatedAt(animal.getApmsUpdatedAt())
+                .apiSource(animal.getApiSource())
+                .createdAt(animal.getCreatedAt())
+                .updatedAt(animal.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 출생 연도로부터 나이 계산
+     * @param birthYear 출생 연도
+     * @return 나이 (null이면 null 반환)
+     */
+    private Integer calculateAge(Integer birthYear) {
+        if (birthYear == null) {
+            return null;
+        }
+        int currentYear = LocalDate.now().getYear();
+        return currentYear - birthYear;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/mapper/ShelterMapper.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/mapper/ShelterMapper.java
@@ -1,0 +1,79 @@
+package com.pawbridge.animalservice.mapper;
+
+import com.pawbridge.animalservice.dto.request.CreateShelterRequest;
+import com.pawbridge.animalservice.dto.response.ShelterDetailResponse;
+import com.pawbridge.animalservice.dto.response.ShelterResponse;
+import com.pawbridge.animalservice.entity.Shelter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Shelter Entity ↔ DTO 변환 매퍼
+ */
+@Component
+public class ShelterMapper {
+
+    // Request DTO → Entity
+
+    /**
+     * CreateShelterRequest → Shelter Entity
+     * - Builder 패턴 사용
+     * @param request 요청 DTO
+     * @return Shelter 엔티티
+     */
+    public Shelter toEntity(CreateShelterRequest request) {
+        return Shelter.builder()
+                .careRegNo(request.getCareRegNo())
+                .name(request.getName())
+                .phone(request.getPhone())
+                .address(request.getAddress())
+                .ownerName(request.getOwnerName())
+                .organizationName(request.getOrganizationName())
+                .email(request.getEmail())
+                .introduction(request.getIntroduction())
+                .adoptionProcedure(request.getAdoptionProcedure())
+                .operatingHours(request.getOperatingHours())
+                .build();
+    }
+
+    // Entity → Response DTO
+
+    /**
+     * Shelter Entity → ShelterResponse (목록 조회용)
+     * @param shelter 보호소 엔티티
+     * @return ShelterResponse DTO
+     */
+    public ShelterResponse toResponse(Shelter shelter) {
+        return ShelterResponse.builder()
+                .id(shelter.getId())
+                .careRegNo(shelter.getCareRegNo())
+                .name(shelter.getName())
+                .phone(shelter.getPhone())
+                .address(shelter.getAddress())
+                .organizationName(shelter.getOrganizationName())
+                .createdAt(shelter.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * Shelter Entity → ShelterDetailResponse (상세 조회용)
+     * @param shelter 보호소 엔티티
+     * @return ShelterDetailResponse DTO
+     */
+    public ShelterDetailResponse toDetailResponse(Shelter shelter) {
+        return ShelterDetailResponse.builder()
+                .id(shelter.getId())
+                .careRegNo(shelter.getCareRegNo())
+                .name(shelter.getName())
+                .phone(shelter.getPhone())
+                .address(shelter.getAddress())
+                .ownerName(shelter.getOwnerName())
+                .organizationName(shelter.getOrganizationName())
+                .email(shelter.getEmail())
+                .introduction(shelter.getIntroduction())
+                .adoptionProcedure(shelter.getAdoptionProcedure())
+                .operatingHours(shelter.getOperatingHours())
+                .createdAt(shelter.getCreatedAt())
+                .updatedAt(shelter.getUpdatedAt())
+                .build();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
@@ -25,8 +25,7 @@ import java.util.Optional;
 @Repository
 public interface AnimalRepository extends JpaRepository<Animal, Long> {
 
-    // ========== 기본 조회 (UNIQUE KEY) ==========
-
+    //기본 조회 (UNIQUE KEY)
     /**
      * APMS 유기번호로 조회 (UNIQUE)
      * - 배치 작업에서 중복 체크용
@@ -42,8 +41,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      */
     boolean existsByApmsDesertionNo(String apmsDesertionNo);
 
-    // ========== 단건 상세 조회 (Shelter 정보 포함) ==========
-
+    //단건 상세 조회 (Shelter 정보 포함)
     /**
      * ID로 동물 조회 (Shelter fetch join)
      * - 상세 페이지용
@@ -62,8 +60,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
     @EntityGraph(attributePaths = {"shelter"})
     Optional<Animal> findWithShelterByApmsDesertionNo(String apmsDesertionNo);
 
-    // ========== 목록 조회 (페이징) - Shelter 불필요 ==========
-
+    // 목록 조회 (페이징) - Shelter 불필요
     /**
      * 축종별 조회
      * - Shelter 정보 불필요 시 사용
@@ -108,7 +105,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      */
     Page<Animal> findByStatusIn(List<AnimalStatus> statuses, Pageable pageable);
 
-    // ========== 목록 조회 (Shelter 정보 필요) ==========
+    // 목록 조회 (Shelter 정보 필요)
     // TODO: DTO 생성 후 프로젝션 방식으로 변경 권장
     //  @Query("SELECT new com.pawbridge.animalservice.dto.AnimalListDto(...) FROM Animal a JOIN a.shelter s")
     //  현재는 @EntityGraph 방식 사용 (Hibernate 경고 발생 가능)
@@ -130,7 +127,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
             Pageable pageable
     );
 
-    // ========== 보호소별 조회 ==========
+    // 보호소별 조회
 
     /**
      * 보호소 ID로 동물 목록 조회
@@ -158,8 +155,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      */
     Page<Animal> findByShelterIdAndStatus(Long shelterId, AnimalStatus status, Pageable pageable);
 
-    // ========== 공고 관련 조회 ==========
-
+    // 공고 관련 조회
     /**
      * 공고 중인 동물 (공고 종료일 임박 순)
      * - 메인 페이지용
@@ -197,8 +193,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
             Pageable pageable
     );
 
-    // ========== 나이 범위 검색 ==========
-
+    // 나이 범위 검색
     /**
      * 출생 연도 범위로 조회
      * - 나이 필터용: 사용자가 "1~3살" 선택 → birthYear BETWEEN (현재-3) AND (현재-1)
@@ -230,8 +225,7 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
             Pageable pageable
     );
 
-    // ========== 텍스트 검색 ==========
-
+    // 텍스트 검색
     /**
      * 품종명으로 검색 (부분 일치)
      * @param breed 품종명 (예: "리트리버")
@@ -256,9 +250,8 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      */
     Page<Animal> findByHappenPlaceContaining(String place, Pageable pageable);
 
-    // ========== 복합 검색 ==========
-    // TODO: 복잡한 동적 쿼리는 Querydsl로 구현 예정
-
+    // 복합 검색
+    // TODO: 복잡한 동적 쿼리는 Querydsl로 구현 예정 -> 미정 엘라스틱 서치로 바꿀 수 있음
     /**
      * 축종 + 품종 검색
      * @param species 축종
@@ -272,8 +265,6 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
             @Param("breed") String breed,
             Pageable pageable
     );
-
-    // ========== 통계 쿼리 ==========
 
     /**
      * 축종별 동물 수 카운트
@@ -303,8 +294,6 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      * @return 개수
      */
     long countBySpeciesAndStatus(Species species, AnimalStatus status);
-
-    // ========== 배치 작업용 ==========
 
     /**
      * 특정 날짜 이후 APMS에서 수정된 동물 조회

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
@@ -1,0 +1,326 @@
+package com.pawbridge.animalservice.repository;
+
+import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.Species;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Animal 엔티티 리포지토리
+ * - 동물 정보 CRUD 및 검색 쿼리
+ * - N+1 문제 방지: 단건 상세는 @EntityGraph, 목록은 DTO 프로젝션 사용
+ */
+@Repository
+public interface AnimalRepository extends JpaRepository<Animal, Long> {
+
+    // ========== 기본 조회 (UNIQUE KEY) ==========
+
+    /**
+     * APMS 유기번호로 조회 (UNIQUE)
+     * - 배치 작업에서 중복 체크용
+     * @param apmsDesertionNo APMS 유기번호
+     * @return Animal Optional
+     */
+    Optional<Animal> findByApmsDesertionNo(String apmsDesertionNo);
+
+    /**
+     * APMS 유기번호 존재 여부 확인
+     * @param apmsDesertionNo APMS 유기번호
+     * @return 존재 여부
+     */
+    boolean existsByApmsDesertionNo(String apmsDesertionNo);
+
+    // ========== 단건 상세 조회 (Shelter 정보 포함) ==========
+
+    /**
+     * ID로 동물 조회 (Shelter fetch join)
+     * - 상세 페이지용
+     * - @EntityGraph로 N+1 방지
+     * @param id 동물 ID
+     * @return Animal Optional with Shelter
+     */
+    @EntityGraph(attributePaths = {"shelter"})
+    Optional<Animal> findWithShelterById(Long id);
+
+    /**
+     * APMS 유기번호로 조회 (Shelter fetch join)
+     * @param apmsDesertionNo APMS 유기번호
+     * @return Animal Optional with Shelter
+     */
+    @EntityGraph(attributePaths = {"shelter"})
+    Optional<Animal> findWithShelterByApmsDesertionNo(String apmsDesertionNo);
+
+    // ========== 목록 조회 (페이징) - Shelter 불필요 ==========
+
+    /**
+     * 축종별 조회
+     * - Shelter 정보 불필요 시 사용
+     * @param species 축종
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findBySpecies(Species species, Pageable pageable);
+
+    /**
+     * 상태별 조회
+     * @param status 상태
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByStatus(AnimalStatus status, Pageable pageable);
+
+    /**
+     * 축종 + 성별 조회
+     * @param species 축종
+     * @param gender 성별
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findBySpeciesAndGender(Species species, Gender gender, Pageable pageable);
+
+    /**
+     * 축종 + 상태 조회
+     * @param species 축종
+     * @param status 상태
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findBySpeciesAndStatus(Species species, AnimalStatus status, Pageable pageable);
+
+    /**
+     * 여러 상태 중 하나에 해당하는 동물 조회
+     * - 예: [NOTICE, PROTECT] → 공고중 또는 보호중
+     * @param statuses 상태 목록
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByStatusIn(List<AnimalStatus> statuses, Pageable pageable);
+
+    // ========== 목록 조회 (Shelter 정보 필요) ==========
+    // TODO: DTO 생성 후 프로젝션 방식으로 변경 권장
+    //  @Query("SELECT new com.pawbridge.animalservice.dto.AnimalListDto(...) FROM Animal a JOIN a.shelter s")
+    //  현재는 @EntityGraph 방식 사용 (Hibernate 경고 발생 가능)
+
+    /**
+     * 축종 + 상태 조회 (Shelter 포함)
+     * - @EntityGraph로 N+1 방지
+     * - Hibernate 경고 발생 가능 (HHH000104)
+     * @param species 축종
+     * @param status 상태
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @EntityGraph(attributePaths = {"shelter"})
+    @Query("SELECT a FROM Animal a WHERE a.species = :species AND a.status = :status")
+    Page<Animal> findBySpeciesAndStatusWithShelter(
+            @Param("species") Species species,
+            @Param("status") AnimalStatus status,
+            Pageable pageable
+    );
+
+    // ========== 보호소별 조회 ==========
+
+    /**
+     * 보호소 ID로 동물 목록 조회
+     * @param shelterId 보호소 ID
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByShelterId(Long shelterId, Pageable pageable);
+
+    /**
+     * 보호소 ID + 축종으로 조회
+     * @param shelterId 보호소 ID
+     * @param species 축종
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByShelterIdAndSpecies(Long shelterId, Species species, Pageable pageable);
+
+    /**
+     * 보호소 ID + 상태로 조회
+     * @param shelterId 보호소 ID
+     * @param status 상태
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByShelterIdAndStatus(Long shelterId, AnimalStatus status, Pageable pageable);
+
+    // ========== 공고 관련 조회 ==========
+
+    /**
+     * 공고 중인 동물 (공고 종료일 임박 순)
+     * - 메인 페이지용
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @Query("SELECT a FROM Animal a WHERE a.status = 'NOTICE' ORDER BY a.noticeEndDate ASC")
+    Page<Animal> findNoticeAnimalsOrderByNoticeEndDate(Pageable pageable);
+
+    /**
+     * 공고 종료일 범위 조회
+     * @param startDate 시작일
+     * @param endDate 종료일
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @Query("SELECT a FROM Animal a WHERE a.noticeEndDate BETWEEN :startDate AND :endDate")
+    Page<Animal> findByNoticeEndDateBetween(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
+    );
+
+    /**
+     * 공고 종료 임박 동물 조회 (D-3 이내)
+     * @param today 오늘 날짜
+     * @param deadline 임박 기준일 (오늘 + 3일)
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @Query("SELECT a FROM Animal a WHERE a.status = 'NOTICE' AND a.noticeEndDate BETWEEN :today AND :deadline ORDER BY a.noticeEndDate ASC")
+    Page<Animal> findExpiringSoonAnimals(
+            @Param("today") LocalDate today,
+            @Param("deadline") LocalDate deadline,
+            Pageable pageable
+    );
+
+    // ========== 나이 범위 검색 ==========
+
+    /**
+     * 출생 연도 범위로 조회
+     * - 나이 필터용: 사용자가 "1~3살" 선택 → birthYear BETWEEN (현재-3) AND (현재-1)
+     * @param startYear 시작 연도
+     * @param endYear 종료 연도
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @Query("SELECT a FROM Animal a WHERE a.birthYear BETWEEN :startYear AND :endYear")
+    Page<Animal> findByBirthYearBetween(
+            @Param("startYear") Integer startYear,
+            @Param("endYear") Integer endYear,
+            Pageable pageable
+    );
+
+    /**
+     * 축종 + 출생 연도 범위로 조회
+     * @param species 축종
+     * @param startYear 시작 연도
+     * @param endYear 종료 연도
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @Query("SELECT a FROM Animal a WHERE a.species = :species AND a.birthYear BETWEEN :startYear AND :endYear")
+    Page<Animal> findBySpeciesAndBirthYearBetween(
+            @Param("species") Species species,
+            @Param("startYear") Integer startYear,
+            @Param("endYear") Integer endYear,
+            Pageable pageable
+    );
+
+    // ========== 텍스트 검색 ==========
+
+    /**
+     * 품종명으로 검색 (부분 일치)
+     * @param breed 품종명 (예: "리트리버")
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByBreedContaining(String breed, Pageable pageable);
+
+    /**
+     * 특징으로 검색 (부분 일치)
+     * @param keyword 검색 키워드
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findBySpecialMarkContaining(String keyword, Pageable pageable);
+
+    /**
+     * 발견 장소로 검색 (부분 일치)
+     * @param place 장소 (예: "남문동")
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    Page<Animal> findByHappenPlaceContaining(String place, Pageable pageable);
+
+    // ========== 복합 검색 ==========
+    // TODO: 복잡한 동적 쿼리는 Querydsl로 구현 예정
+
+    /**
+     * 축종 + 품종 검색
+     * @param species 축종
+     * @param breed 품종 키워드
+     * @param pageable 페이징 정보
+     * @return Page<Animal>
+     */
+    @Query("SELECT a FROM Animal a WHERE a.species = :species AND a.breed LIKE %:breed%")
+    Page<Animal> findBySpeciesAndBreedContaining(
+            @Param("species") Species species,
+            @Param("breed") String breed,
+            Pageable pageable
+    );
+
+    // ========== 통계 쿼리 ==========
+
+    /**
+     * 축종별 동물 수 카운트
+     * @param species 축종
+     * @return 개수
+     */
+    long countBySpecies(Species species);
+
+    /**
+     * 상태별 동물 수 카운트
+     * @param status 상태
+     * @return 개수
+     */
+    long countByStatus(AnimalStatus status);
+
+    /**
+     * 보호소별 동물 수 카운트
+     * @param shelterId 보호소 ID
+     * @return 개수
+     */
+    long countByShelterId(Long shelterId);
+
+    /**
+     * 축종 + 상태별 카운트
+     * @param species 축종
+     * @param status 상태
+     * @return 개수
+     */
+    long countBySpeciesAndStatus(Species species, AnimalStatus status);
+
+    // ========== 배치 작업용 ==========
+
+    /**
+     * 특정 날짜 이후 APMS에서 수정된 동물 조회
+     * - APMS 동기화 시 증분 업데이트용
+     * @param dateTime 기준 날짜시간
+     * @return 동물 목록
+     */
+    @Query("SELECT a FROM Animal a WHERE a.apmsUpdatedAt > :dateTime")
+    List<Animal> findByApmsUpdatedAtAfter(@Param("dateTime") LocalDateTime dateTime);
+
+    /**
+     * 공고 종료일이 지난 동물 조회
+     * - 상태 자동 업데이트 배치용
+     * @param today 오늘 날짜
+     * @return 동물 목록
+     */
+    @Query("SELECT a FROM Animal a WHERE a.status = 'NOTICE' AND a.noticeEndDate < :today")
+    List<Animal> findExpiredNoticeAnimals(@Param("today") LocalDate today);
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/ShelterRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/ShelterRepository.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 @Repository
 public interface ShelterRepository extends JpaRepository<Shelter, Long> {
 
-    // ========== 기본 조회 (UNIQUE KEY) ==========
-
+    // 기본 조회 (UNIQUE KEY)
     /**
      * APMS 보호소 등록번호로 조회 (UNIQUE)
      * - 배치 작업에서 Shelter 조회/생성 시 사용
@@ -35,8 +34,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
      */
     boolean existsByCareRegNo(String careRegNo);
 
-    // ========== 텍스트 검색 (페이징) ==========
-
+    // 텍스트 검색 (페이징)
     /**
      * 보호소 이름으로 검색 (부분 일치)
      * - 사용자가 보호소 검색 시 사용
@@ -63,8 +61,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
      */
     Page<Shelter> findByOrganizationNameContaining(String organizationName, Pageable pageable);
 
-    // ========== 복합 검색 ==========
-
+    // 복합 검색
     /**
      * 이름 또는 주소로 검색
      * - 통합 검색용
@@ -80,8 +77,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
             Pageable pageable
     );
 
-    // ========== 배치 작업용 ==========
-
+    // 배치 작업용
     /**
      * 여러 개의 careRegNo로 Shelter 조회
      * - 배치 작업에서 대량의 Shelter를 한 번에 조회
@@ -92,8 +88,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
     @Query("SELECT s FROM Shelter s WHERE s.careRegNo IN :careRegNos")
     List<Shelter> findByCareRegNoIn(@Param("careRegNos") List<String> careRegNos);
 
-    // ========== 통계 쿼리 ==========
-
+    // 통계 쿼리
     /**
      * 전체 보호소 수 카운트
      * @return 보호소 개수

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/ShelterRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/ShelterRepository.java
@@ -1,0 +1,103 @@
+package com.pawbridge.animalservice.repository;
+
+import com.pawbridge.animalservice.entity.Shelter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Shelter 엔티티 리포지토리
+ * - 보호소 정보 CRUD 및 검색 쿼리
+ */
+@Repository
+public interface ShelterRepository extends JpaRepository<Shelter, Long> {
+
+    // ========== 기본 조회 (UNIQUE KEY) ==========
+
+    /**
+     * APMS 보호소 등록번호로 조회 (UNIQUE)
+     * - 배치 작업에서 Shelter 조회/생성 시 사용
+     * @param careRegNo APMS 보호소 등록번호
+     * @return Shelter Optional
+     */
+    Optional<Shelter> findByCareRegNo(String careRegNo);
+
+    /**
+     * APMS 보호소 등록번호 존재 여부 확인
+     * @param careRegNo APMS 보호소 등록번호
+     * @return 존재 여부
+     */
+    boolean existsByCareRegNo(String careRegNo);
+
+    // ========== 텍스트 검색 (페이징) ==========
+
+    /**
+     * 보호소 이름으로 검색 (부분 일치)
+     * - 사용자가 보호소 검색 시 사용
+     * @param name 보호소 이름 (예: "창원")
+     * @param pageable 페이징 정보
+     * @return Page<Shelter>
+     */
+    Page<Shelter> findByNameContaining(String name, Pageable pageable);
+
+    /**
+     * 보호소 주소로 검색 (부분 일치)
+     * - 지역별 보호소 검색
+     * @param address 주소 키워드 (예: "경상남도", "창원시")
+     * @param pageable 페이징 정보
+     * @return Page<Shelter>
+     */
+    Page<Shelter> findByAddressContaining(String address, Pageable pageable);
+
+    /**
+     * 관할 기관으로 검색 (부분 일치)
+     * @param organizationName 관할 기관명 (예: "창원시")
+     * @param pageable 페이징 정보
+     * @return Page<Shelter>
+     */
+    Page<Shelter> findByOrganizationNameContaining(String organizationName, Pageable pageable);
+
+    // ========== 복합 검색 ==========
+
+    /**
+     * 이름 또는 주소로 검색
+     * - 통합 검색용
+     * @param name 보호소 이름 키워드
+     * @param address 주소 키워드
+     * @param pageable 페이징 정보
+     * @return Page<Shelter>
+     */
+    @Query("SELECT s FROM Shelter s WHERE s.name LIKE %:name% OR s.address LIKE %:address%")
+    Page<Shelter> findByNameOrAddress(
+            @Param("name") String name,
+            @Param("address") String address,
+            Pageable pageable
+    );
+
+    // ========== 배치 작업용 ==========
+
+    /**
+     * 여러 개의 careRegNo로 Shelter 조회
+     * - 배치 작업에서 대량의 Shelter를 한 번에 조회
+     * - IN 절로 N+1 방지
+     * @param careRegNos APMS 보호소 등록번호 목록
+     * @return Shelter 목록
+     */
+    @Query("SELECT s FROM Shelter s WHERE s.careRegNo IN :careRegNos")
+    List<Shelter> findByCareRegNoIn(@Param("careRegNos") List<String> careRegNos);
+
+    // ========== 통계 쿼리 ==========
+
+    /**
+     * 전체 보호소 수 카운트
+     * @return 보호소 개수
+     */
+    @Query("SELECT COUNT(s) FROM Shelter s")
+    long countAllShelters();
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/AnimalCommandService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/AnimalCommandService.java
@@ -1,0 +1,155 @@
+package com.pawbridge.animalservice.service;
+
+import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.entity.Shelter;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.repository.AnimalRepository;
+import com.pawbridge.animalservice.repository.ShelterRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Animal Command Service (CUD)
+ * - 동물 생성, 수정, 삭제 담당
+ * - 쓰기 작업 트랜잭션 관리
+ */
+@Service
+@RequiredArgsConstructor
+public class AnimalCommandService {
+
+    private final AnimalRepository animalRepository;
+    private final ShelterRepository shelterRepository;
+
+    // ========== 생성 ==========
+
+    /**
+     * 동물 생성 (보호소 직접 등록)
+     * - Shelter는 이미 존재해야 함
+     * @param animal 동물 정보
+     * @return 저장된 Animal
+     * @throws EntityNotFoundException Shelter가 없을 때
+     */
+    @Transactional
+    public Animal create(Animal animal) {
+        // Shelter 존재 확인
+        Shelter shelter = shelterRepository.findById(animal.getShelter().getId())
+                .orElseThrow(() -> new EntityNotFoundException("Shelter not found: " + animal.getShelter().getId()));
+
+        animal.setShelter(shelter);
+        return animalRepository.save(animal);
+    }
+
+    // ========== 수정 ==========
+
+    /**
+     * 동물 상태 변경
+     * @param id 동물 ID
+     * @param newStatus 새로운 상태
+     * @return 수정된 Animal
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    @Transactional
+    public Animal updateStatus(Long id, AnimalStatus newStatus) {
+        Animal animal = animalRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + id));
+
+        animal.updateStatus(newStatus);  // Entity 메서드 활용
+        return animal;  // dirty checking
+    }
+
+    /**
+     * 보호소 설명 수정
+     * @param id 동물 ID
+     * @param description 설명
+     * @return 수정된 Animal
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    @Transactional
+    public Animal updateDescription(Long id, String description) {
+        Animal animal = animalRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + id));
+
+        animal.setDescription(description);
+        return animal;
+    }
+
+    /**
+     * 찜 횟수 증가
+     * - user-service에서 Kafka 이벤트 받아 호출
+     * @param id 동물 ID
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    @Transactional
+    public void incrementFavoriteCount(Long id) {
+        Animal animal = animalRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + id));
+
+        animal.incrementFavoriteCount();
+    }
+
+    /**
+     * 찜 횟수 감소
+     * @param id 동물 ID
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    @Transactional
+    public void decrementFavoriteCount(Long id) {
+        Animal animal = animalRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + id));
+
+        animal.decrementFavoriteCount();
+    }
+
+    // ========== 삭제 ==========
+
+    /**
+     * 동물 삭제
+     * @param id 동물 ID
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    @Transactional
+    public void delete(Long id) {
+        if (!animalRepository.existsById(id)) {
+            throw new EntityNotFoundException("Animal not found: " + id);
+        }
+        animalRepository.deleteById(id);
+    }
+
+    // ========== 배치 작업용 ==========
+
+    /**
+     * APMS 데이터로부터 동물 생성 (배치 전용)
+     * - 중복 체크 포함
+     * @param animal 동물 정보
+     * @return 저장된 Animal
+     * @throws IllegalStateException 이미 존재하는 동물일 때
+     */
+    @Transactional
+    public Animal createFromApms(Animal animal) {
+        // 중복 체크
+        if (animalRepository.existsByApmsDesertionNo(animal.getApmsDesertionNo())) {
+            throw new IllegalStateException("Animal already exists: " + animal.getApmsDesertionNo());
+        }
+
+        return animalRepository.save(animal);
+    }
+
+    /**
+     * 공고 종료된 동물 상태 일괄 업데이트
+     * - 배치 작업용: NOTICE → PROTECT
+     * @return 업데이트된 개수
+     */
+    @Transactional
+    public int updateExpiredNoticeAnimals() {
+        List<Animal> expiredAnimals = animalRepository.findExpiredNoticeAnimals(LocalDate.now());
+
+        expiredAnimals.forEach(animal -> animal.updateStatus(AnimalStatus.PROTECT));
+
+        return expiredAnimals.size();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/AnimalQueryService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/AnimalQueryService.java
@@ -1,0 +1,257 @@
+package com.pawbridge.animalservice.service;
+
+import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.Species;
+import com.pawbridge.animalservice.repository.AnimalRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Animal Query Service (R)
+ * - 동물 조회, 검색 담당
+ * - 읽기 전용 트랜잭션
+ */
+@Service
+@Transactional(readOnly = true)  // 클래스 레벨: 읽기 전용
+@RequiredArgsConstructor
+public class AnimalQueryService {
+
+    private final AnimalRepository animalRepository;
+
+    // ========== 단건 조회 ==========
+
+    /**
+     * ID로 동물 조회 (Shelter 없음)
+     * @param id 동물 ID
+     * @return Animal
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    public Animal findById(Long id) {
+        return animalRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + id));
+    }
+
+    /**
+     * ID로 동물 조회 (Shelter 포함)
+     * - @EntityGraph로 N+1 방지
+     * @param id 동물 ID
+     * @return Animal with Shelter
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    public Animal findByIdWithShelter(Long id) {
+        return animalRepository.findWithShelterById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + id));
+    }
+
+    /**
+     * APMS 유기번호로 조회
+     * @param apmsDesertionNo APMS 유기번호
+     * @return Animal
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    public Animal findByApmsDesertionNo(String apmsDesertionNo) {
+        return animalRepository.findByApmsDesertionNo(apmsDesertionNo)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + apmsDesertionNo));
+    }
+
+    /**
+     * APMS 유기번호로 조회 (Shelter 포함)
+     * @param apmsDesertionNo APMS 유기번호
+     * @return Animal with Shelter
+     * @throws EntityNotFoundException 동물이 없을 때
+     */
+    public Animal findByApmsDesertionNoWithShelter(String apmsDesertionNo) {
+        return animalRepository.findWithShelterByApmsDesertionNo(apmsDesertionNo)
+                .orElseThrow(() -> new EntityNotFoundException("Animal not found: " + apmsDesertionNo));
+    }
+
+    // ========== 목록 조회 (기본) ==========
+
+    /**
+     * 축종별 조회
+     */
+    public Page<Animal> findBySpecies(Species species, Pageable pageable) {
+        return animalRepository.findBySpecies(species, pageable);
+    }
+
+    /**
+     * 상태별 조회
+     */
+    public Page<Animal> findByStatus(AnimalStatus status, Pageable pageable) {
+        return animalRepository.findByStatus(status, pageable);
+    }
+
+    /**
+     * 축종 + 성별 조회
+     */
+    public Page<Animal> findBySpeciesAndGender(Species species, Gender gender, Pageable pageable) {
+        return animalRepository.findBySpeciesAndGender(species, gender, pageable);
+    }
+
+    /**
+     * 축종 + 상태 조회
+     */
+    public Page<Animal> findBySpeciesAndStatus(Species species, AnimalStatus status, Pageable pageable) {
+        return animalRepository.findBySpeciesAndStatus(species, status, pageable);
+    }
+
+    /**
+     * 여러 상태 조회
+     */
+    public Page<Animal> findByStatusIn(List<AnimalStatus> statuses, Pageable pageable) {
+        return animalRepository.findByStatusIn(statuses, pageable);
+    }
+
+    /**
+     * 축종 + 상태 조회 (Shelter 포함)
+     */
+    public Page<Animal> findBySpeciesAndStatusWithShelter(Species species, AnimalStatus status, Pageable pageable) {
+        return animalRepository.findBySpeciesAndStatusWithShelter(species, status, pageable);
+    }
+
+    // ========== 공고 관련 조회 ==========
+
+    /**
+     * 공고 중인 동물 (공고 종료일 임박 순)
+     * - 메인 페이지용
+     */
+    public Page<Animal> findNoticeAnimalsOrderByNoticeEndDate(Pageable pageable) {
+        return animalRepository.findNoticeAnimalsOrderByNoticeEndDate(pageable);
+    }
+
+    /**
+     * 공고 종료 임박 동물 (D-3 이내)
+     */
+    public Page<Animal> findExpiringSoonAnimals(Pageable pageable) {
+        LocalDate today = LocalDate.now();
+        LocalDate deadline = today.plusDays(3);
+        return animalRepository.findExpiringSoonAnimals(today, deadline, pageable);
+    }
+
+    /**
+     * 공고 종료일 범위 조회
+     */
+    public Page<Animal> findByNoticeEndDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable) {
+        return animalRepository.findByNoticeEndDateBetween(startDate, endDate, pageable);
+    }
+
+    // ========== 나이 범위 검색 ==========
+
+    /**
+     * 출생 연도 범위 조회
+     */
+    public Page<Animal> findByBirthYearBetween(Integer startYear, Integer endYear, Pageable pageable) {
+        return animalRepository.findByBirthYearBetween(startYear, endYear, pageable);
+    }
+
+    /**
+     * 축종 + 출생 연도 범위 조회
+     */
+    public Page<Animal> findBySpeciesAndBirthYearBetween(
+            Species species, Integer startYear, Integer endYear, Pageable pageable) {
+        return animalRepository.findBySpeciesAndBirthYearBetween(species, startYear, endYear, pageable);
+    }
+
+    // ========== 텍스트 검색 ==========
+
+    /**
+     * 품종명 검색
+     */
+    public Page<Animal> searchByBreed(String breed, Pageable pageable) {
+        return animalRepository.findByBreedContaining(breed, pageable);
+    }
+
+    /**
+     * 특징 검색
+     */
+    public Page<Animal> searchBySpecialMark(String keyword, Pageable pageable) {
+        return animalRepository.findBySpecialMarkContaining(keyword, pageable);
+    }
+
+    /**
+     * 발견 장소 검색
+     */
+    public Page<Animal> searchByHappenPlace(String place, Pageable pageable) {
+        return animalRepository.findByHappenPlaceContaining(place, pageable);
+    }
+
+    /**
+     * 축종 + 품종 검색
+     */
+    public Page<Animal> searchBySpeciesAndBreed(Species species, String breed, Pageable pageable) {
+        return animalRepository.findBySpeciesAndBreedContaining(species, breed, pageable);
+    }
+
+    // ========== 보호소별 조회 ==========
+
+    /**
+     * 보호소 ID로 동물 목록 조회
+     */
+    public Page<Animal> findByShelterId(Long shelterId, Pageable pageable) {
+        return animalRepository.findByShelterId(shelterId, pageable);
+    }
+
+    /**
+     * 보호소 ID + 축종 조회
+     */
+    public Page<Animal> findByShelterIdAndSpecies(Long shelterId, Species species, Pageable pageable) {
+        return animalRepository.findByShelterIdAndSpecies(shelterId, species, pageable);
+    }
+
+    /**
+     * 보호소 ID + 상태 조회
+     */
+    public Page<Animal> findByShelterIdAndStatus(Long shelterId, AnimalStatus status, Pageable pageable) {
+        return animalRepository.findByShelterIdAndStatus(shelterId, status, pageable);
+    }
+
+    // ========== 통계 ==========
+
+    /**
+     * 축종별 카운트
+     */
+    public long countBySpecies(Species species) {
+        return animalRepository.countBySpecies(species);
+    }
+
+    /**
+     * 상태별 카운트
+     */
+    public long countByStatus(AnimalStatus status) {
+        return animalRepository.countByStatus(status);
+    }
+
+    /**
+     * 보호소별 카운트
+     */
+    public long countByShelterId(Long shelterId) {
+        return animalRepository.countByShelterId(shelterId);
+    }
+
+    /**
+     * 축종 + 상태별 카운트
+     */
+    public long countBySpeciesAndStatus(Species species, AnimalStatus status) {
+        return animalRepository.countBySpeciesAndStatus(species, status);
+    }
+
+    // ========== 배치 작업용 ==========
+
+    /**
+     * APMS 수정 이후 동물 조회
+     * - 증분 업데이트용
+     */
+    public List<Animal> findByApmsUpdatedAtAfter(LocalDateTime dateTime) {
+        return animalRepository.findByApmsUpdatedAtAfter(dateTime);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/ShelterCommandService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/ShelterCommandService.java
@@ -1,6 +1,10 @@
 package com.pawbridge.animalservice.service;
 
+import com.pawbridge.animalservice.dto.request.CreateShelterRequest;
+import com.pawbridge.animalservice.dto.request.UpdateShelterRequest;
+import com.pawbridge.animalservice.dto.response.ShelterDetailResponse;
 import com.pawbridge.animalservice.entity.Shelter;
+import com.pawbridge.animalservice.mapper.ShelterMapper;
 import com.pawbridge.animalservice.repository.ShelterRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -11,29 +15,37 @@ import org.springframework.transaction.annotation.Transactional;
  * Shelter Command Service (CUD)
  * - 보호소 생성, 수정, 삭제 담당
  * - 쓰기 작업 트랜잭션 관리
+ * - DTO 기반 처리
  */
 @Service
 @RequiredArgsConstructor
 public class ShelterCommandService {
 
     private final ShelterRepository shelterRepository;
-
-    // ========== 생성 ==========
+    private final ShelterMapper mapper;
 
     /**
      * 보호소 생성
-     * @param shelter 보호소 정보
-     * @return 저장된 Shelter
+     * @param request 보호소 등록 요청 DTO
+     * @return ShelterDetailResponse
      */
     @Transactional
-    public Shelter create(Shelter shelter) {
-        return shelterRepository.save(shelter);
+    public ShelterDetailResponse create(CreateShelterRequest request) {
+        // DTO → Entity 변환
+        Shelter shelter = mapper.toEntity(request);
+
+        // 저장
+        Shelter saved = shelterRepository.save(shelter);
+
+        // Entity → Response DTO
+        return mapper.toDetailResponse(saved);
     }
 
     /**
      * APMS 데이터로부터 보호소 생성 (배치 전용)
      * - 중복 체크 포함
-     * @param shelter 보호소 정보
+     * - ApmsShelterMapper에서 Entity를 만들어서 전달
+     * @param shelter 보호소 Entity
      * @return 저장된 Shelter
      * @throws IllegalStateException 이미 존재하는 보호소일 때
      */
@@ -47,31 +59,29 @@ public class ShelterCommandService {
         return shelterRepository.save(shelter);
     }
 
-    // ========== 수정 ==========
-
     /**
      * 보호소 정보 수정 (보호소 회원이 직접 수정)
-     * - Entity의 updateInfo 메서드 활용
      * @param id 보호소 ID
-     * @param phone 전화번호
-     * @param email 이메일
-     * @param introduction 소개
-     * @param adoptionProcedure 입양 절차
-     * @param operatingHours 운영 시간
-     * @return 수정된 Shelter
+     * @param request 수정 요청 DTO
+     * @return ShelterDetailResponse
      * @throws EntityNotFoundException 보호소가 없을 때
      */
     @Transactional
-    public Shelter update(Long id, String phone, String email,
-                         String introduction, String adoptionProcedure, String operatingHours) {
+    public ShelterDetailResponse update(Long id, UpdateShelterRequest request) {
         Shelter shelter = shelterRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Shelter not found: " + id));
 
-        shelter.updateInfo(phone, email, introduction, adoptionProcedure, operatingHours);
-        return shelter;  // dirty checking
-    }
+        // Entity의 비즈니스 메서드 활용
+        shelter.updateInfo(
+                request.getPhone(),
+                request.getEmail(),
+                request.getIntroduction(),
+                request.getAdoptionProcedure(),
+                request.getOperatingHours()
+        );
 
-    // ========== 삭제 ==========
+        return mapper.toDetailResponse(shelter);
+    }
 
     /**
      * 보호소 삭제

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/ShelterCommandService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/ShelterCommandService.java
@@ -1,0 +1,88 @@
+package com.pawbridge.animalservice.service;
+
+import com.pawbridge.animalservice.entity.Shelter;
+import com.pawbridge.animalservice.repository.ShelterRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Shelter Command Service (CUD)
+ * - 보호소 생성, 수정, 삭제 담당
+ * - 쓰기 작업 트랜잭션 관리
+ */
+@Service
+@RequiredArgsConstructor
+public class ShelterCommandService {
+
+    private final ShelterRepository shelterRepository;
+
+    // ========== 생성 ==========
+
+    /**
+     * 보호소 생성
+     * @param shelter 보호소 정보
+     * @return 저장된 Shelter
+     */
+    @Transactional
+    public Shelter create(Shelter shelter) {
+        return shelterRepository.save(shelter);
+    }
+
+    /**
+     * APMS 데이터로부터 보호소 생성 (배치 전용)
+     * - 중복 체크 포함
+     * @param shelter 보호소 정보
+     * @return 저장된 Shelter
+     * @throws IllegalStateException 이미 존재하는 보호소일 때
+     */
+    @Transactional
+    public Shelter createFromApms(Shelter shelter) {
+        // 중복 체크
+        if (shelterRepository.existsByCareRegNo(shelter.getCareRegNo())) {
+            throw new IllegalStateException("Shelter already exists: " + shelter.getCareRegNo());
+        }
+
+        return shelterRepository.save(shelter);
+    }
+
+    // ========== 수정 ==========
+
+    /**
+     * 보호소 정보 수정 (보호소 회원이 직접 수정)
+     * - Entity의 updateInfo 메서드 활용
+     * @param id 보호소 ID
+     * @param phone 전화번호
+     * @param email 이메일
+     * @param introduction 소개
+     * @param adoptionProcedure 입양 절차
+     * @param operatingHours 운영 시간
+     * @return 수정된 Shelter
+     * @throws EntityNotFoundException 보호소가 없을 때
+     */
+    @Transactional
+    public Shelter update(Long id, String phone, String email,
+                         String introduction, String adoptionProcedure, String operatingHours) {
+        Shelter shelter = shelterRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Shelter not found: " + id));
+
+        shelter.updateInfo(phone, email, introduction, adoptionProcedure, operatingHours);
+        return shelter;  // dirty checking
+    }
+
+    // ========== 삭제 ==========
+
+    /**
+     * 보호소 삭제
+     * @param id 보호소 ID
+     * @throws EntityNotFoundException 보호소가 없을 때
+     */
+    @Transactional
+    public void delete(Long id) {
+        if (!shelterRepository.existsById(id)) {
+            throw new EntityNotFoundException("Shelter not found: " + id);
+        }
+        shelterRepository.deleteById(id);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/ShelterQueryService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/ShelterQueryService.java
@@ -1,0 +1,105 @@
+package com.pawbridge.animalservice.service;
+
+import com.pawbridge.animalservice.entity.Shelter;
+import com.pawbridge.animalservice.repository.ShelterRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Shelter Query Service (R)
+ * - 보호소 조회, 검색 담당
+ * - 읽기 전용 트랜잭션
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ShelterQueryService {
+
+    private final ShelterRepository shelterRepository;
+
+    // ========== 단건 조회 ==========
+
+    /**
+     * ID로 보호소 조회
+     * @param id 보호소 ID
+     * @return Shelter
+     * @throws EntityNotFoundException 보호소가 없을 때
+     */
+    public Shelter findById(Long id) {
+        return shelterRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Shelter not found: " + id));
+    }
+
+    /**
+     * APMS 보호소 등록번호로 조회
+     * @param careRegNo APMS 보호소 등록번호
+     * @return Shelter
+     * @throws EntityNotFoundException 보호소가 없을 때
+     */
+    public Shelter findByCareRegNo(String careRegNo) {
+        return shelterRepository.findByCareRegNo(careRegNo)
+                .orElseThrow(() -> new EntityNotFoundException("Shelter not found: " + careRegNo));
+    }
+
+    // ========== 목록 조회 ==========
+
+    /**
+     * 전체 보호소 조회
+     */
+    public Page<Shelter> findAll(Pageable pageable) {
+        return shelterRepository.findAll(pageable);
+    }
+
+    /**
+     * 보호소 이름으로 검색
+     */
+    public Page<Shelter> searchByName(String name, Pageable pageable) {
+        return shelterRepository.findByNameContaining(name, pageable);
+    }
+
+    /**
+     * 보호소 주소로 검색
+     */
+    public Page<Shelter> searchByAddress(String address, Pageable pageable) {
+        return shelterRepository.findByAddressContaining(address, pageable);
+    }
+
+    /**
+     * 관할 기관으로 검색
+     */
+    public Page<Shelter> searchByOrganizationName(String organizationName, Pageable pageable) {
+        return shelterRepository.findByOrganizationNameContaining(organizationName, pageable);
+    }
+
+    /**
+     * 이름 또는 주소로 검색
+     */
+    public Page<Shelter> searchByNameOrAddress(String keyword, Pageable pageable) {
+        return shelterRepository.findByNameOrAddress(keyword, keyword, pageable);
+    }
+
+    // ========== 배치 작업용 ==========
+
+    /**
+     * 여러 개의 careRegNo로 Shelter 조회
+     * - 배치 작업에서 대량 조회
+     */
+    public List<Shelter> findByCareRegNoIn(List<String> careRegNos) {
+        return shelterRepository.findByCareRegNoIn(careRegNos);
+    }
+
+    // ========== 통계 ==========
+
+    /**
+     * 전체 보호소 수 카운트
+     */
+    public long countAll() {
+        return shelterRepository.countAllShelters();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/util/ResponseDto.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/util/ResponseDto.java
@@ -1,0 +1,66 @@
+package com.pawbridge.animalservice.util;
+
+import com.pawbridge.animalservice.exception.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ResponseDto<T> {
+    private final int code;
+    private final String message;
+    private final T data;
+
+    @Builder
+    private ResponseDto(int code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 성공 응답 (메시지만 반환)
+    public static ResponseDto<Void> ok() {
+        return ResponseDto.<Void>builder()
+                .code(HttpStatus.OK.value())
+                .message(null)
+                .build();
+    }
+
+    // 성공 응답 (메시지만 반환)
+    public static ResponseDto<Void> okWithMessage(String message) {
+        return ResponseDto.<Void>builder()
+                .code(HttpStatus.OK.value())
+                .message(message)
+                .build();
+    }
+
+    // 1. 메시지 없이 호출하는 경우
+    public static <T> ResponseDto<T> okWithData(T data) {
+        return okWithData(data, "요청이 성공적으로 처리되었습니다.");
+    }
+
+    // 2. 메시지와 함께 호출하는 경우 (실제 로직)
+    public static <T> ResponseDto<T> okWithData(T data, String message) {
+        return ResponseDto.<T>builder()
+                .code(HttpStatus.OK.value())
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    // 에러 응답
+    public static ResponseDto<Void> error(ErrorCode errorCode) {
+        return ResponseDto.<Void>builder()
+                .code(errorCode.getHttpStatus().value())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    public static ResponseDto<Void> errorWithMessage(HttpStatus httpStatus, String errorMessage) {
+        return ResponseDto.<Void>builder()
+                .code(httpStatus.value())
+                .message(errorMessage)
+                .data(null)
+                .build();
+    }
+}

--- a/animal-service/src/main/resources/application.yml
+++ b/animal-service/src/main/resources/application.yml
@@ -1,0 +1,71 @@
+spring:
+  application:
+    name: animal-service
+
+  # Database Settings
+  datasource:
+    url: jdbc:mysql://localhost:3306/pawbridge_animal?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  # JPA Settings
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+        show_sql: true
+        use_sql_comments: true
+    open-in-view: false
+
+  # Kafka Settings (Phase 3)
+  # kafka:
+  #   bootstrap-servers: localhost:9092
+  #   producer:
+  #     key-serializer: org.apache.kafka.common.serialization.StringSerializer
+  #     value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+  #   consumer:
+  #     group-id: animal-service
+  #     auto-offset-reset: earliest
+  #     key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+  #     value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+  #     properties:
+  #       spring.json.trusted.packages: com.pawbridge.*
+
+# Server Settings
+server:
+  port: 8082
+  servlet:
+    context-path: /
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+# Logging Settings
+logging:
+  level:
+    com.pawbridge.animalservice: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
+
+# Actuator Settings
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: when-authorized


### PR DESCRIPTION
## 변경 사항
### 엔티티 및 도메인
- Animal, Shelter 엔티티 추가
- BaseTimeEntity 추가 (JPA Auditing)
- Enum 추가 (Species, Gender, AnimalStatus, NeuterStatus, ApiSource)

### 아키텍처 패턴
- CQRS 패턴 적용 (CommandService, QueryService)
- Facade 레이어 추가 (Controller ↔ Service 조율)

### API 구현
- AnimalController: 동물 CRUD + 검색 API
- ShelterController: 보호소 CRUD API
- DTO 및 Mapper 구현 (Entity ↔ DTO 변환)

### 예외 처리
- ApplicationException 기반 예외 계층 구조
- ErrorCode enum으로 중앙 관리
- GlobalExceptionHandler (11개 예외 핸들러)
- ResponseDto 통일 (성공/실패 응답)

### 설정
- application.yml 추가 (DB, JPA, Server, Logging, Actuator)
- JpaConfig (@EnableJpaAuditing)

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #2 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함(추후 별도 이슈에서 진행)
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

