### PR TITLE
feat: animal-service 검색/필터 API 구현 및 Repository 리팩토링

### DIFF
--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/AnimalSearchRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/AnimalSearchRequest.java
@@ -1,0 +1,79 @@
+package com.pawbridge.animalservice.dto.request;
+
+import com.pawbridge.animalservice.enums.AnimalStatus;
+import com.pawbridge.animalservice.enums.Gender;
+import com.pawbridge.animalservice.enums.NeuterStatus;
+import com.pawbridge.animalservice.enums.Species;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 동물 검색 요청 DTO
+ * - Phase 1: MySQL Specification 기반 검색
+ * - Phase 4: OpenSearch 전환 예정
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalSearchRequest {
+
+    /**
+     * 축종 (개, 고양이, 기타)
+     */
+    private Species species;
+
+    /**
+     * 품종 (부분 검색)
+     */
+    private String breed;
+
+    /**
+     * 성별
+     */
+    private Gender gender;
+
+    /**
+     * 중성화 여부
+     */
+    private NeuterStatus neuterStatus;
+
+    /**
+     * 동물 상태 (공고중, 보호중 등)
+     */
+    private AnimalStatus status;
+
+    /**
+     * 나이 범위 - 최소 (만 나이)
+     * 예: minAge=1 → 1살 이상
+     */
+    private Integer minAge;
+
+    /**
+     * 나이 범위 - 최대 (만 나이)
+     * 예: maxAge=5 → 5살 이하
+     */
+    private Integer maxAge;
+
+    /**
+     * 지역 검색 (시도)
+     * 예: "서울", "경기", "부산"
+     * Shelter.careAddr에서 LIKE 검색
+     */
+    private String region;
+
+    /**
+     * 지역 검색 (시군구)
+     * 예: "강남구", "수원시"
+     * Shelter.careAddr에서 LIKE 검색
+     */
+    private String city;
+
+    /**
+     * 키워드 검색 (품종 + 특징 + 발견장소 통합 검색)
+     * - breed, specialMark, happenPlace에서 OR 검색
+     */
+    private String keyword;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateAnimalStatusRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/UpdateAnimalStatusRequest.java
@@ -20,7 +20,7 @@ public class UpdateAnimalStatusRequest {
 
     /**
      * 새로운 상태
-     * - NOTICE, PROTECT, ADOPTION_PENDING, ADOPTED, RETURNED_TO_OWNER, EUTHANIZED 등
+     * - PROTECT, ADOPTION_PENDING, ADOPTED, RETURNED_TO_OWNER, EUTHANIZED 등
      */
     @NotNull(message = "새로운 상태는 필수입니다")
     private AnimalStatus newStatus;

--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/AnimalResponse.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/response/AnimalResponse.java
@@ -60,6 +60,11 @@ public class AnimalResponse {
     private Integer age;
 
     /**
+     * 특징
+     */
+    private String specialMark;
+
+    /**
      * 동물 상태
      */
     private AnimalStatus status;

--- a/animal-service/src/main/java/com/pawbridge/animalservice/enums/AnimalStatus.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/enums/AnimalStatus.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum AnimalStatus {
-    NOTICE("공고중"),
     PROTECT("보호중"),
     ADOPTION_PENDING("입양대기중"),    // 입양 절차 진행 중
     ADOPTED("종료(입양)"),

--- a/animal-service/src/main/java/com/pawbridge/animalservice/facade/AnimalFacade.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/facade/AnimalFacade.java
@@ -1,5 +1,6 @@
 package com.pawbridge.animalservice.facade;
 
+import com.pawbridge.animalservice.dto.request.AnimalSearchRequest;
 import com.pawbridge.animalservice.dto.request.CreateAnimalRequest;
 import com.pawbridge.animalservice.dto.request.UpdateAnimalDescriptionRequest;
 import com.pawbridge.animalservice.dto.request.UpdateAnimalStatusRequest;
@@ -96,8 +97,8 @@ public class AnimalFacade {
      * 공고 종료된 동물 상태 일괄 업데이트 (배치)
      */
     @Transactional
-    public int updateExpiredNoticeAnimals() {
-        return commandService.updateExpiredNoticeAnimals();
+    public int updateExpiredProtectAnimals() {
+        return commandService.updateExpiredProtectAnimals();
     }
 
     /**
@@ -116,53 +117,6 @@ public class AnimalFacade {
         return queryService.findByApmsDesertionNo(apmsDesertionNo);
     }
 
-    /**
-     * 축종별 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findBySpecies(Species species, Pageable pageable) {
-        return queryService.findBySpecies(species, pageable);
-    }
-
-    /**
-     * 상태별 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findByStatus(AnimalStatus status, Pageable pageable) {
-        return queryService.findByStatus(status, pageable);
-    }
-
-    /**
-     * 축종 + 성별 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findBySpeciesAndGender(Species species, Gender gender, Pageable pageable) {
-        return queryService.findBySpeciesAndGender(species, gender, pageable);
-    }
-
-    /**
-     * 축종 + 상태 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findBySpeciesAndStatus(Species species, AnimalStatus status, Pageable pageable) {
-        return queryService.findBySpeciesAndStatus(species, status, pageable);
-    }
-
-    /**
-     * 여러 상태 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findByStatusIn(List<AnimalStatus> statuses, Pageable pageable) {
-        return queryService.findByStatusIn(statuses, pageable);
-    }
-
-    /**
-     * 공고 중인 동물 (공고 종료일 임박 순)
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findNoticeAnimalsOrderByNoticeEndDate(Pageable pageable) {
-        return queryService.findNoticeAnimalsOrderByNoticeEndDate(pageable);
-    }
 
     /**
      * 공고 종료 임박 동물 (D-3 이내)
@@ -172,62 +126,6 @@ public class AnimalFacade {
         return queryService.findExpiringSoonAnimals(pageable);
     }
 
-    /**
-     * 공고 종료일 범위 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findByNoticeEndDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable) {
-        return queryService.findByNoticeEndDateBetween(startDate, endDate, pageable);
-    }
-
-    /**
-     * 출생 연도 범위 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findByBirthYearBetween(Integer startYear, Integer endYear, Pageable pageable) {
-        return queryService.findByBirthYearBetween(startYear, endYear, pageable);
-    }
-
-    /**
-     * 축종 + 출생 연도 범위 조회
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> findBySpeciesAndBirthYearBetween(
-            Species species, Integer startYear, Integer endYear, Pageable pageable) {
-        return queryService.findBySpeciesAndBirthYearBetween(species, startYear, endYear, pageable);
-    }
-
-    /**
-     * 품종명 검색
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> searchByBreed(String breed, Pageable pageable) {
-        return queryService.searchByBreed(breed, pageable);
-    }
-
-    /**
-     * 특징 검색
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> searchBySpecialMark(String keyword, Pageable pageable) {
-        return queryService.searchBySpecialMark(keyword, pageable);
-    }
-
-    /**
-     * 발견 장소 검색
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> searchByHappenPlace(String place, Pageable pageable) {
-        return queryService.searchByHappenPlace(place, pageable);
-    }
-
-    /**
-     * 축종 + 품종 검색
-     */
-    @Transactional(readOnly = true)
-    public Page<AnimalResponse> searchBySpeciesAndBreed(Species species, String breed, Pageable pageable) {
-        return queryService.searchBySpeciesAndBreed(species, breed, pageable);
-    }
 
     /**
      * 보호소 ID로 동물 목록 조회
@@ -292,5 +190,19 @@ public class AnimalFacade {
     @Transactional(readOnly = true)
     public List<Animal> findByApmsUpdatedAtAfter(LocalDateTime dateTime) {
         return queryService.findByApmsUpdatedAtAfter(dateTime);
+    }
+
+    /**
+     * 동물 통합 검색 (동적 쿼리)
+     * - Phase 1: MySQL Specification 기반
+     * - Phase 4: OpenSearch로 전환 예정
+     *
+     * @param request 검색 조건
+     * @param pageable 페이징 정보
+     * @return Page<AnimalResponse>
+     */
+    @Transactional(readOnly = true)
+    public Page<AnimalResponse> searchAnimals(AnimalSearchRequest request, Pageable pageable) {
+        return queryService.searchAnimals(request, pageable);
     }
 }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/mapper/AnimalMapper.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/mapper/AnimalMapper.java
@@ -62,6 +62,7 @@ public class AnimalMapper {
                 .gender(animal.getGender())
                 .birthYear(animal.getBirthYear())
                 .age(calculateAge(animal.getBirthYear()))
+                .specialMark(animal.getSpecialMark())
                 .status(animal.getStatus())
                 .noticeEndDate(animal.getNoticeEndDate())
                 .imageUrl(animal.getImageUrl())

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
@@ -21,9 +21,11 @@ import java.util.Optional;
  * Animal 엔티티 리포지토리
  * - 동물 정보 CRUD 및 검색 쿼리
  * - N+1 문제 방지: 단건 상세는 @EntityGraph, 목록은 DTO 프로젝션 사용
+ * - JpaSpecificationExecutor: 동적 검색 쿼리 지원 (Phase 1 - OpenSearch 전환 전까지)
  */
 @Repository
-public interface AnimalRepository extends JpaRepository<Animal, Long> {
+public interface AnimalRepository extends JpaRepository<Animal, Long>,
+                                          org.springframework.data.jpa.repository.JpaSpecificationExecutor<Animal> {
 
     //기본 조회 (UNIQUE KEY)
     /**
@@ -60,72 +62,6 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
     @EntityGraph(attributePaths = {"shelter"})
     Optional<Animal> findWithShelterByApmsDesertionNo(String apmsDesertionNo);
 
-    // 목록 조회 (페이징) - Shelter 불필요
-    /**
-     * 축종별 조회
-     * - Shelter 정보 불필요 시 사용
-     * @param species 축종
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findBySpecies(Species species, Pageable pageable);
-
-    /**
-     * 상태별 조회
-     * @param status 상태
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findByStatus(AnimalStatus status, Pageable pageable);
-
-    /**
-     * 축종 + 성별 조회
-     * @param species 축종
-     * @param gender 성별
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findBySpeciesAndGender(Species species, Gender gender, Pageable pageable);
-
-    /**
-     * 축종 + 상태 조회
-     * @param species 축종
-     * @param status 상태
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findBySpeciesAndStatus(Species species, AnimalStatus status, Pageable pageable);
-
-    /**
-     * 여러 상태 중 하나에 해당하는 동물 조회
-     * - 예: [NOTICE, PROTECT] → 공고중 또는 보호중
-     * @param statuses 상태 목록
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findByStatusIn(List<AnimalStatus> statuses, Pageable pageable);
-
-    // 목록 조회 (Shelter 정보 필요)
-    // TODO: DTO 생성 후 프로젝션 방식으로 변경 권장
-    //  @Query("SELECT new com.pawbridge.animalservice.dto.AnimalListDto(...) FROM Animal a JOIN a.shelter s")
-    //  현재는 @EntityGraph 방식 사용 (Hibernate 경고 발생 가능)
-
-    /**
-     * 축종 + 상태 조회 (Shelter 포함)
-     * - @EntityGraph로 N+1 방지
-     * - Hibernate 경고 발생 가능 (HHH000104)
-     * @param species 축종
-     * @param status 상태
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    @EntityGraph(attributePaths = {"shelter"})
-    @Query("SELECT a FROM Animal a WHERE a.species = :species AND a.status = :status")
-    Page<Animal> findBySpeciesAndStatusWithShelter(
-            @Param("species") Species species,
-            @Param("status") AnimalStatus status,
-            Pageable pageable
-    );
 
     // 보호소별 조회
 
@@ -156,28 +92,6 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
     Page<Animal> findByShelterIdAndStatus(Long shelterId, AnimalStatus status, Pageable pageable);
 
     // 공고 관련 조회
-    /**
-     * 공고 중인 동물 (공고 종료일 임박 순)
-     * - 메인 페이지용
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    @Query("SELECT a FROM Animal a WHERE a.status = 'NOTICE' ORDER BY a.noticeEndDate ASC")
-    Page<Animal> findNoticeAnimalsOrderByNoticeEndDate(Pageable pageable);
-
-    /**
-     * 공고 종료일 범위 조회
-     * @param startDate 시작일
-     * @param endDate 종료일
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    @Query("SELECT a FROM Animal a WHERE a.noticeEndDate BETWEEN :startDate AND :endDate")
-    Page<Animal> findByNoticeEndDateBetween(
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate,
-            Pageable pageable
-    );
 
     /**
      * 공고 종료 임박 동물 조회 (D-3 이내)
@@ -186,85 +100,13 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      * @param pageable 페이징 정보
      * @return Page<Animal>
      */
-    @Query("SELECT a FROM Animal a WHERE a.status = 'NOTICE' AND a.noticeEndDate BETWEEN :today AND :deadline ORDER BY a.noticeEndDate ASC")
+    @Query("SELECT a FROM Animal a WHERE a.status = 'PROTECT' AND a.noticeEndDate BETWEEN :today AND :deadline ORDER BY a.noticeEndDate ASC")
     Page<Animal> findExpiringSoonAnimals(
             @Param("today") LocalDate today,
             @Param("deadline") LocalDate deadline,
             Pageable pageable
     );
 
-    // 나이 범위 검색
-    /**
-     * 출생 연도 범위로 조회
-     * - 나이 필터용: 사용자가 "1~3살" 선택 → birthYear BETWEEN (현재-3) AND (현재-1)
-     * @param startYear 시작 연도
-     * @param endYear 종료 연도
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    @Query("SELECT a FROM Animal a WHERE a.birthYear BETWEEN :startYear AND :endYear")
-    Page<Animal> findByBirthYearBetween(
-            @Param("startYear") Integer startYear,
-            @Param("endYear") Integer endYear,
-            Pageable pageable
-    );
-
-    /**
-     * 축종 + 출생 연도 범위로 조회
-     * @param species 축종
-     * @param startYear 시작 연도
-     * @param endYear 종료 연도
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    @Query("SELECT a FROM Animal a WHERE a.species = :species AND a.birthYear BETWEEN :startYear AND :endYear")
-    Page<Animal> findBySpeciesAndBirthYearBetween(
-            @Param("species") Species species,
-            @Param("startYear") Integer startYear,
-            @Param("endYear") Integer endYear,
-            Pageable pageable
-    );
-
-    // 텍스트 검색
-    /**
-     * 품종명으로 검색 (부분 일치)
-     * @param breed 품종명 (예: "리트리버")
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findByBreedContaining(String breed, Pageable pageable);
-
-    /**
-     * 특징으로 검색 (부분 일치)
-     * @param keyword 검색 키워드
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findBySpecialMarkContaining(String keyword, Pageable pageable);
-
-    /**
-     * 발견 장소로 검색 (부분 일치)
-     * @param place 장소 (예: "남문동")
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    Page<Animal> findByHappenPlaceContaining(String place, Pageable pageable);
-
-    // 복합 검색
-    // TODO: 복잡한 동적 쿼리는 Querydsl로 구현 예정 -> 미정 엘라스틱 서치로 바꿀 수 있음
-    /**
-     * 축종 + 품종 검색
-     * @param species 축종
-     * @param breed 품종 키워드
-     * @param pageable 페이징 정보
-     * @return Page<Animal>
-     */
-    @Query("SELECT a FROM Animal a WHERE a.species = :species AND a.breed LIKE %:breed%")
-    Page<Animal> findBySpeciesAndBreedContaining(
-            @Param("species") Species species,
-            @Param("breed") String breed,
-            Pageable pageable
-    );
 
     /**
      * 축종별 동물 수 카운트
@@ -310,6 +152,6 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
      * @param today 오늘 날짜
      * @return 동물 목록
      */
-    @Query("SELECT a FROM Animal a WHERE a.status = 'NOTICE' AND a.noticeEndDate < :today")
-    List<Animal> findExpiredNoticeAnimals(@Param("today") LocalDate today);
+    @Query("SELECT a FROM Animal a WHERE a.status = 'PROTECT' AND a.noticeEndDate < :today")
+    List<Animal> findExpiredProtectAnimals(@Param("today") LocalDate today);
 }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/AnimalCommandService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/AnimalCommandService.java
@@ -149,14 +149,16 @@ public class AnimalCommandService {
 
     /**
      * 공고 종료된 동물 상태 일괄 업데이트
-     * - 배치 작업용: NOTICE → PROTECT
+     * - 배치 작업용: 공고 종료일이 지난 보호 중인 동물 처리
+     * - 현재는 PROTECT 상태 유지 (향후 다른 로직 추가 가능)
      * @return 업데이트된 개수
      */
     @Transactional
-    public int updateExpiredNoticeAnimals() {
-        List<Animal> expiredAnimals = animalRepository.findExpiredNoticeAnimals(LocalDate.now());
+    public int updateExpiredProtectAnimals() {
+        List<Animal> expiredAnimals = animalRepository.findExpiredProtectAnimals(LocalDate.now());
 
-        expiredAnimals.forEach(animal -> animal.updateStatus(AnimalStatus.PROTECT));
+        // 향후 필요 시 상태 변경 로직 추가
+        // 예: expiredAnimals.forEach(animal -> animal.updateStatus(AnimalStatus.UNKNOWN));
 
         return expiredAnimals.size();
     }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/specification/AnimalSpecification.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/specification/AnimalSpecification.java
@@ -1,0 +1,121 @@
+package com.pawbridge.animalservice.specification;
+
+import com.pawbridge.animalservice.dto.request.AnimalSearchRequest;
+import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.entity.Shelter;
+import jakarta.persistence.criteria.*;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Animal 동적 검색 Specification
+ * - Phase 1: MySQL 기반 임시 구현
+ * - Phase 4: OpenSearch 전환 시 제거 예정
+ */
+public class AnimalSpecification {
+
+    /**
+     * AnimalSearchRequest 기반 동적 쿼리 생성
+     *
+     * @param request 검색 조건
+     * @return Specification<Animal>
+     */
+    public static Specification<Animal> searchAnimals(AnimalSearchRequest request) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // 1. 축종 필터
+            if (request.getSpecies() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("species"), request.getSpecies()));
+            }
+
+            // 2. 품종 필터 (부분 검색)
+            if (request.getBreed() != null && !request.getBreed().isBlank()) {
+                predicates.add(criteriaBuilder.like(root.get("breed"), "%" + request.getBreed() + "%"));
+            }
+
+            // 3. 성별 필터
+            if (request.getGender() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("gender"), request.getGender()));
+            }
+
+            // 4. 중성화 여부 필터
+            if (request.getNeuterStatus() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("neuterStatus"), request.getNeuterStatus()));
+            }
+
+            // 5. 상태 필터
+            if (request.getStatus() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("status"), request.getStatus()));
+            }
+
+            // 6. 나이 범위 필터 (birthYear 계산)
+            if (request.getMinAge() != null || request.getMaxAge() != null) {
+                int currentYear = Year.now().getValue();
+
+                // minAge=1 → birthYear <= 현재-1 (1살 이상)
+                if (request.getMinAge() != null) {
+                    int maxBirthYear = currentYear - request.getMinAge();
+                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("birthYear"), maxBirthYear));
+                }
+
+                // maxAge=5 → birthYear >= 현재-5 (5살 이하)
+                if (request.getMaxAge() != null) {
+                    int minBirthYear = currentYear - request.getMaxAge();
+                    predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("birthYear"), minBirthYear));
+                }
+            }
+
+            // 7. 지역 필터 (Shelter.address)
+            if ((request.getRegion() != null && !request.getRegion().isBlank()) ||
+                    (request.getCity() != null && !request.getCity().isBlank())) {
+
+                Join<Animal, Shelter> shelterJoin = root.join("shelter", JoinType.INNER);
+
+                // 시도 검색 (예: "서울", "경기")
+                if (request.getRegion() != null && !request.getRegion().isBlank()) {
+                    predicates.add(criteriaBuilder.like(shelterJoin.get("address"), "%" + request.getRegion() + "%"));
+                }
+
+                // 시군구 검색 (예: "강남구", "수원시")
+                if (request.getCity() != null && !request.getCity().isBlank()) {
+                    predicates.add(criteriaBuilder.like(shelterJoin.get("address"), "%" + request.getCity() + "%"));
+                }
+            }
+
+            // 8. 키워드 통합 검색 (품종 OR 특징 OR 발견장소)
+            if (request.getKeyword() != null && !request.getKeyword().isBlank()) {
+                String keywordPattern = "%" + request.getKeyword() + "%";
+
+                Predicate breedLike = criteriaBuilder.like(root.get("breed"), keywordPattern);
+                Predicate specialMarkLike = criteriaBuilder.like(root.get("specialMark"), keywordPattern);
+                Predicate happenPlaceLike = criteriaBuilder.like(root.get("happenPlace"), keywordPattern);
+
+                predicates.add(criteriaBuilder.or(breedLike, specialMarkLike, happenPlaceLike));
+            }
+
+            // 9. 모든 조건 AND로 결합
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    /**
+     * Shelter를 fetch join하는 Specification
+     * - N+1 방지용
+     * - 검색 조건과 조합하여 사용
+     *
+     * @return Specification<Animal>
+     */
+    public static Specification<Animal> fetchShelter() {
+        return (root, query, criteriaBuilder) -> {
+            // 중복 fetch 방지: count 쿼리에서는 fetch join 제외
+            if (query.getResultType() != Long.class && query.getResultType() != long.class) {
+                root.fetch("shelter", JoinType.LEFT);
+            }
+            return criteriaBuilder.conjunction(); // 조건 없음 (항상 true)
+        };
+    }
+}

--- a/animal-service/src/main/resources/application.yml
+++ b/animal-service/src/main/resources/application.yml
@@ -49,7 +49,7 @@ spring:
 
 # Server Settings
 server:
-  port: 8082
+  port: 9020
   servlet:
     context-path: /
     encoding:


### PR DESCRIPTION
## 변경 사항
### 검색/필터 API 구현
- **AnimalSearchRequest DTO 추가**: 10개 필터 조건 지원 (축종, 품종, 성별, 중성화, 상태, 나이 범위, 지역, 키워드)
- **AnimalSpecification 구현**: JPA Criteria API 기반 동적 쿼리 생성
- **Controller 통합 엔드포인트**: `GET /api/animals` - 파라미터에 따라 전체 조회/필터링 자동 전환
- **Shelter JOIN 지원**: 지역 검색 시 보호소 주소 기반 필터링
- **키워드 통합 검색**: 품종, 특징, 발견장소에서 OR 조건 검색

### Repository 리팩토링
- **13개 중복 메서드 삭제** (26개 → 13개): Specification으로 완전 대체 가능한 메서드 제거
- **유지한 메서드**: 보호소별 조회, 통계 카운트, APMS 연동, 공고 관련 (향후 사용 예정)

### 버그 수정 및 개선
- **AnimalStatus NOTICE 제거**: APMS 실제 데이터에 없는 상태 제거
- **Shelter 필드명 수정**: `careAddr` → `address` (지역 검색 500 에러 해결)
- **누락 엔드포인트 추가**: APMS 유기번호 조회, 찜 기능 증가/감소

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #8 

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
### 주요 기술적 결정

1. **JPA Specification 선택 (Querydsl 대신)**
   - Phase 4에서 OpenSearch로 전환 예정이므로 최소한의 구현
   - 동적 쿼리 지원은 충분하며 추가 의존성 불필요

2. **통합 검색 엔드포인트**
   - RESTful 원칙 준수: 리소스 중심 설계
   - 프론트엔드 사용 단순화: 하나의 엔드포인트로 모든 조회 처리

3. **Repository 메서드 정리 기준**
   - 삭제: Specification으로 대체 가능한 단순 필터 메서드
   - 유지: 확정된 요구사항 (통계 API, 보호소별 조회 등)

### API 사용 예시

```http
# 전체 조회
GET /api/animals

# 축종별 조회
GET /api/animals?species=DOG

# 복합 필터
GET /api/animals?species=DOG&region=서울&minAge=1&maxAge=5

# 키워드 검색
GET /api/animals?keyword=믹스

# 공고 종료 임박 (D-3)
GET /api/animals/expiring-soon