### PR TITLE
feat: Kafka 연동 개선 - 단일 토픽 + Delegator 패턴 + 보상 트랜잭션

### DIFF
--- a/animal-service/build.gradle
+++ b/animal-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/animal-service/src/main/java/com/pawbridge/animalservice/AnimalServiceApplication.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/AnimalServiceApplication.java
@@ -2,12 +2,8 @@ package com.pawbridge.animalservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class AnimalServiceApplication {
 
 	public static void main(String[] args) {

--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/BatchConfig.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/BatchConfig.java
@@ -1,13 +1,22 @@
 package com.pawbridge.animalservice.config;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * Spring Batch 설정
+ *
+ * Spring Boot 3.x에서는 @EnableBatchProcessing 불필요
+ * - spring-boot-starter-batch 의존성만으로 자동 설정됨
+ * - JobRepository, JobLauncher 등이 자동으로 빈 등록됨
+ *
+ * Job과 Step은 batch 패키지에서 정의:
+ * - batch/job/ApmsAnimalBatchJob.java
+ * - batch/reader/ApmsItemReader.java
+ * - batch/processor/AnimalItemProcessor.java
+ * - batch/writer/AnimalItemWriter.java
  */
 @Configuration
-//@EnableBatchProcessing
 public class BatchConfig {
-    // Job과 Step은 별도 클래스에서 정의
+    // Spring Boot 3.x Auto-configuration 사용
+    // 커스텀 설정 필요 시 여기에 @Bean 추가
 }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/KafkaConsumerConfig.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/KafkaConsumerConfig.java
@@ -109,9 +109,11 @@ public class KafkaConsumerConfig {
 
                                 // Outbox 패턴으로 보상 이벤트 발행
                                 outboxService.saveEvent(
-                                        "user.compensation.events",
-                                        userId.toString(),
-                                        compensationEvent
+                                        "FavoriteCompensation",              // aggregateType
+                                        userId.toString(),                    // aggregateId
+                                        "FAVORITE_COMPENSATION_REQUIRED",    // eventType
+                                        "user.compensation.events",          // topic
+                                        compensationEvent                     // payload
                                 );
 
                                 log.warn("[RECOVERER] Compensation event published for FAVORITE_ADDED: " +

--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/KafkaConsumerConfig.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/KafkaConsumerConfig.java
@@ -1,0 +1,209 @@
+package com.pawbridge.animalservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawbridge.animalservice.event.FavoriteCompensationEvent;
+import com.pawbridge.animalservice.service.OutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    private final OutboxService outboxService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    // 재시도 설정
+    private static final long RETRY_INTERVAL_MS = 1000L; // 1초 간격
+    private static final long MAX_RETRY_ATTEMPTS = 3L;   // 최대 3회 재시도
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        // JSON 역직렬화 설정
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.pawbridge.*");
+        configProps.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        configProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "java.util.Map");
+
+        // Consumer 설정
+        configProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    /**
+     * 에러 핸들러 설정 (재시도 + 보상 트랜잭션)
+     *
+     * 동작:
+     * 1. 재시도: 1초 간격, 최대 3회
+     * 2. 재시도 실패 시 Recoverer 호출 → 보상 트랜잭션 발행
+     *
+     * Recoverer (Saga 패턴 보상 트랜잭션):
+     * - FAVORITE_ADDED 실패 → user-service에 ROLLBACK_FAVORITE_ADDED 이벤트 발행
+     *   (user-service가 삭제한 favorite 레코드를 다시 삭제)
+     * - FAVORITE_REMOVED 실패 → 보상 불필요 (로그만 남김, Eventually Consistent)
+     *
+     * FATAL-ERROR 처리:
+     * - 보상 이벤트 저장 실패 시 try-catch로 잡아서 FATAL-ERROR 로그 남김
+     * - Consumer 블로킹 방지 (무한 루프 방지)
+     * - 운영팀 수동 개입 필요 (Slack/PagerDuty 연동 권장)
+     */
+    @Bean
+    public CommonErrorHandler errorHandler() {
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+                (record, ex) -> {
+                    // ===== Recoverer: 모든 재시도 실패 시 호출 =====
+                    try {
+                        // 1. 페이로드 파싱
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> payload = (Map<String, Object>) record.value();
+                        String eventType = (String) payload.get("eventType");
+                        String eventId = (String) payload.get("eventId");
+                        Long userId = ((Number) payload.get("userId")).longValue();
+                        Long animalId = ((Number) payload.get("animalId")).longValue();
+
+                        log.error("[RECOVERER] All retries exhausted for topic={}, partition={}, offset={}, eventType={}, eventId={}",
+                                record.topic(), record.partition(), record.offset(), eventType, eventId);
+
+                        // 2. eventType에 따라 보상 전략 결정
+                        switch (eventType) {
+                            case "FAVORITE_ADDED":
+                                // FAVORITE_ADDED 실패 → user-service에 보상 이벤트 발행
+                                // user-service는 favorite 레코드 삭제 (롤백)
+                                FavoriteCompensationEvent compensationEvent =
+                                        FavoriteCompensationEvent.forAddedFailure(
+                                                eventId,
+                                                userId,
+                                                animalId,
+                                                "animal-service failed to increment favoriteCount after " +
+                                                        MAX_RETRY_ATTEMPTS + " retries. Error: " + ex.getMessage()
+                                        );
+
+                                // Outbox 패턴으로 보상 이벤트 발행
+                                outboxService.saveEvent(
+                                        "user.compensation.events",
+                                        userId.toString(),
+                                        compensationEvent
+                                );
+
+                                log.warn("[RECOVERER] Compensation event published for FAVORITE_ADDED: " +
+                                                "eventId={}, userId={}, animalId={}, compensationEventId={}",
+                                        eventId, userId, animalId, compensationEvent.getEventId());
+                                break;
+
+                            case "FAVORITE_REMOVED":
+                                // FAVORITE_REMOVED 실패 → 보상 불필요
+                                // 이유: user-service는 이미 favorite 삭제 완료 (사용자 의도 달성)
+                                //       animal-service의 favoriteCount 불일치는 Eventually Consistent로 처리
+                                //       (정기 배치 또는 다음 찜 추가 시 자연스럽게 맞춰짐)
+                                log.warn("[RECOVERER] FAVORITE_REMOVED failed, but compensation NOT needed. " +
+                                                "favoriteCount will be eventually consistent. " +
+                                                "eventId={}, userId={}, animalId={}",
+                                        eventId, userId, animalId);
+                                break;
+
+                            default:
+                                log.error("[RECOVERER] Unknown eventType, cannot determine compensation strategy: " +
+                                                "eventType={}, eventId={}, payload={}",
+                                        eventType, eventId, payload);
+                        }
+
+                    } catch (Exception compensationEx) {
+                        // ===== FATAL-ERROR: 보상 트랜잭션 자체가 실패 =====
+                        // try-catch로 감싸서 Consumer 블로킹 방지
+                        // 운영팀 수동 개입 필요 (Slack/PagerDuty 알림 권장)
+                        log.error("""
+                                        ╔══════════════════════════════════════════════════════════════════╗
+                                        ║                         🚨 FATAL-ERROR 🚨                        ║
+                                        ║          Compensation transaction failed to save!                ║
+                                        ║              Manual intervention required!                       ║
+                                        ╚══════════════════════════════════════════════════════════════════╝
+
+                                        Topic: {}
+                                        Partition: {}
+                                        Offset: {}
+
+                                        Original Payload:
+                                        {}
+
+                                        Original Error:
+                                        {}
+
+                                        Compensation Error:
+                                        {}
+
+                                        Action Required:
+                                        1. Check user-service database for inconsistent favorite records
+                                        2. Manually publish compensation event or fix data
+                                        3. Investigate why OutboxService.saveEvent() failed
+                                        4. Monitor for cascading failures
+                                        """,
+                                record.topic(),
+                                record.partition(),
+                                record.offset(),
+                                record.value(),
+                                ex.getMessage(),
+                                compensationEx.getMessage(),
+                                compensationEx
+                        );
+
+                        // Consumer가 멈추지 않도록 예외를 삼킴 (swallow)
+                        // DLT로 전송하지 않음 (보상 실패는 수동 처리 필요)
+                    }
+                },
+                new FixedBackOff(RETRY_INTERVAL_MS, MAX_RETRY_ATTEMPTS)
+        );
+
+        // 재시도 로그
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) ->
+                log.warn("[KAFKA-RETRY] Retry attempt {}/{} for topic={}, partition={}, offset={}",
+                        deliveryAttempt, MAX_RETRY_ATTEMPTS, record.topic(), record.partition(), record.offset())
+        );
+
+        return errorHandler;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+            CommonErrorHandler errorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // 수동 커밋 모드 설정
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+
+        // 에러 핸들러 설정 (재시도 + DLQ)
+        factory.setCommonErrorHandler(errorHandler);
+
+        return factory;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/KafkaProducerConfig.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/KafkaProducerConfig.java
@@ -1,0 +1,44 @@
+package com.pawbridge.animalservice.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        // JSON 직렬화 설정
+        configProps.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+
+        // 성능 및 안정성 설정
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all"); // 모든 replica 확인
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3); // 재시도 3회
+        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 멱등성 보장
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/SchedulerConfig.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.pawbridge.animalservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/consumer/FavoriteEventConsumer.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/consumer/FavoriteEventConsumer.java
@@ -1,0 +1,88 @@
+package com.pawbridge.animalservice.consumer;
+
+import com.pawbridge.animalservice.handler.FavoriteEventHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Favorite 이벤트 Kafka Consumer (Delegator 패턴)
+ *
+ * 역할:
+ * - 단일 토픽(user.favorite.events)에서 이벤트 수신
+ * - eventType 필드로 이벤트 구분
+ * - 파싱 및 검증만 수행, 비즈니스 로직은 Handler에 위임
+ * - 예외 발생 시 throw → DefaultErrorHandler가 재시도 처리
+ * - 재시도 실패 시 Recoverer가 보상 트랜잭션 발행
+ *
+ * 단일 토픽 이유:
+ * - favoriteCount는 숫자 필드로 순서가 중요 (DB 조회로 검증 불가)
+ * - 동일한 animalId는 동일 파티션으로 전송 → FIFO 보장
+ * - 찜 추가(+1) → 찜 취소(-1) 순서 보장 필수
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FavoriteEventConsumer {
+
+    private final FavoriteEventHandler favoriteEventHandler;
+
+    /**
+     * Favorite 이벤트 통합 리스너
+     *
+     * @param payload 이벤트 페이로드 (eventType, eventId, userId, animalId 포함)
+     * @param ack     수동 Acknowledgment (처리 성공 시에만 커밋)
+     * @throws IllegalArgumentException eventType 또는 eventId 누락/불명 시
+     * @throws Exception                비즈니스 로직 실패 시 (DefaultErrorHandler가 재시도)
+     */
+    @KafkaListener(topics = "user.favorite.events", groupId = "animal-service-favorite-group")
+    public void consumeFavoriteEvent(Map<String, Object> payload, Acknowledgment ack) {
+        // 1. eventType, eventId 필수 검증
+        String eventType = (String) payload.get("eventType");
+        String eventId = (String) payload.get("eventId");
+
+        if (eventType == null || eventType.isBlank()) {
+            log.error("[CONSUMER] Missing eventType, cannot route event: payload={}", payload);
+            throw new IllegalArgumentException("eventType is required");
+        }
+
+        if (eventId == null || eventId.isBlank()) {
+            log.error("[CONSUMER] Missing eventId, cannot guarantee idempotency: payload={}", payload);
+            throw new IllegalArgumentException("eventId is required for idempotency");
+        }
+
+        // 2. 필드 추출
+        Long animalId = ((Number) payload.get("animalId")).longValue();
+        Long userId = ((Number) payload.get("userId")).longValue();
+
+        log.info("[CONSUMER] Received favorite event: eventType={}, eventId={}, animalId={}, userId={}",
+                eventType, eventId, animalId, userId);
+
+        // 3. eventType에 따라 Handler 메서드 호출 (Delegator 패턴)
+        //    예외 발생 시 throw → DefaultErrorHandler 재시도 → Recoverer 보상 트랜잭션
+        switch (eventType) {
+            case "FAVORITE_ADDED":
+                favoriteEventHandler.addFavorite(eventId, userId, animalId);
+                break;
+
+            case "FAVORITE_REMOVED":
+                favoriteEventHandler.removeFavorite(eventId, userId, animalId);
+                break;
+
+            default:
+                log.error("[CONSUMER] Unknown eventType: eventType={}, payload={}", eventType, payload);
+                throw new IllegalArgumentException("Unknown eventType: " + eventType);
+        }
+
+        // 4. 처리 성공 시 수동 커밋
+        //    Handler에서 예외 발생 시 이 라인에 도달하지 않음 → 오프셋 커밋 안 됨 → 재시도
+        ack.acknowledge();
+
+        log.info("[CONSUMER] Successfully processed favorite event: eventType={}, eventId={}, animalId={}",
+                eventType, eventId, animalId);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/OutboxEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/OutboxEvent.java
@@ -1,0 +1,123 @@
+package com.pawbridge.animalservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Outbox Pattern을 위한 이벤트 저장 엔티티
+ * - 트랜잭션과 함께 이벤트를 저장하여 원자성 보장
+ * - 별도 스케줄러가 폴링하여 Kafka로 발행
+ */
+@Entity
+@Table(name = "outbox_events",
+        indexes = {
+                @Index(name = "idx_outbox_status", columnList = "status"),
+                @Index(name = "idx_outbox_created_at", columnList = "createdAt")
+        })
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 이벤트 고유 ID (멱등성 보장용)
+     */
+    @Column(nullable = false, unique = true, length = 50)
+    private String eventId;
+
+    /**
+     * Aggregate 타입 (예: Animal, Shelter)
+     */
+    @Column(nullable = false, length = 50)
+    private String aggregateType;
+
+    /**
+     * Aggregate ID (예: animalId, shelterId)
+     */
+    @Column(nullable = false, length = 50)
+    private String aggregateId;
+
+    /**
+     * 이벤트 타입 (예: ANIMAL_CREATED, ANIMAL_STATUS_CHANGED)
+     */
+    @Column(nullable = false, length = 50)
+    private String eventType;
+
+    /**
+     * Kafka 토픽 이름
+     */
+    @Column(nullable = false, length = 100)
+    private String topic;
+
+    /**
+     * 이벤트 페이로드 (JSON)
+     */
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    /**
+     * 이벤트 상태
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboxStatus status;
+
+    /**
+     * 생성 시각
+     */
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 발행 시각
+     */
+    private LocalDateTime publishedAt;
+
+    /**
+     * 재시도 횟수
+     */
+    @Builder.Default
+    @Column(nullable = false)
+    private Integer retryCount = 0;
+
+    /**
+     * 마지막 에러 메시지
+     */
+    @Column(length = 500)
+    private String lastError;
+
+    /**
+     * 이벤트 상태 Enum
+     */
+    public enum OutboxStatus {
+        PENDING,    // 발행 대기
+        PUBLISHED,  // 발행 완료
+        FAILED      // 발행 실패 (재시도 초과)
+    }
+
+    /**
+     * 발행 완료 처리
+     */
+    public void markAsPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 발행 실패 처리
+     */
+    public void markAsFailed(String errorMessage) {
+        this.retryCount++;
+        this.lastError = errorMessage;
+        if (this.retryCount >= 3) {
+            this.status = OutboxStatus.FAILED;
+        }
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/entity/ProcessedEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/entity/ProcessedEvent.java
@@ -1,0 +1,53 @@
+package com.pawbridge.animalservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Consumer 멱등성을 위한 처리된 이벤트 기록 엔티티
+ * - eventId로 중복 처리 방지
+ * - 같은 이벤트가 여러 번 전달되어도 한 번만 처리
+ */
+@Entity
+@Table(name = "processed_events",
+        indexes = {
+                @Index(name = "idx_processed_at", columnList = "processedAt")
+        })
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProcessedEvent {
+
+    /**
+     * 이벤트 고유 ID (Producer가 생성한 UUID)
+     */
+    @Id
+    @Column(length = 50)
+    private String eventId;
+
+    /**
+     * 이벤트 타입 (디버깅/모니터링용)
+     */
+    @Column(nullable = false, length = 50)
+    private String eventType;
+
+    /**
+     * 처리 시각
+     */
+    @Column(nullable = false)
+    private LocalDateTime processedAt;
+
+    /**
+     * 정적 팩토리 메서드
+     */
+    public static ProcessedEvent of(String eventId, String eventType) {
+        return ProcessedEvent.builder()
+                .eventId(eventId)
+                .eventType(eventType)
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/event/AnimalCreatedEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/event/AnimalCreatedEvent.java
@@ -1,0 +1,24 @@
+package com.pawbridge.animalservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalCreatedEvent {
+
+    private String eventId;
+    private String eventType;
+    private LocalDateTime timestamp;
+    private Long animalId;
+    private String species;
+    private String breed;
+    private String status;
+    private Long shelterId;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/event/AnimalStatusChangedEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/event/AnimalStatusChangedEvent.java
@@ -1,0 +1,24 @@
+package com.pawbridge.animalservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalStatusChangedEvent {
+
+    private String eventId;
+    private String eventType;
+    private LocalDateTime timestamp;
+    private Long animalId;
+    private String oldStatus;
+    private String newStatus;
+    private String animalName;
+    private String species;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/event/AnimalUpdatedEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/event/AnimalUpdatedEvent.java
@@ -1,0 +1,22 @@
+package com.pawbridge.animalservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnimalUpdatedEvent {
+
+    private String eventId;
+    private String eventType;
+    private LocalDateTime timestamp;
+    private Long animalId;
+    private Map<String, Object> updatedFields;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/event/FavoriteAddedEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/event/FavoriteAddedEvent.java
@@ -1,0 +1,21 @@
+package com.pawbridge.animalservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteAddedEvent {
+
+    private String eventId;
+    private String eventType;
+    private LocalDateTime timestamp;
+    private Long userId;
+    private Long animalId;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/event/FavoriteCompensationEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/event/FavoriteCompensationEvent.java
@@ -1,0 +1,124 @@
+package com.pawbridge.animalservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 찜 이벤트 처리 실패 시 보상을 위한 이벤트
+ * - user-service가 구독하여 원래 작업을 롤백
+ * - Saga 패턴의 보상 트랜잭션 구현
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteCompensationEvent {
+
+    /**
+     * 보상 이벤트 고유 ID (멱등성)
+     */
+    private String eventId;
+
+    /**
+     * 이벤트 타입 고정값
+     */
+    private String eventType;
+
+    /**
+     * 보상 이벤트 발생 시각
+     */
+    private LocalDateTime timestamp;
+
+    /**
+     * 실패한 원본 이벤트 ID
+     */
+    private String originalEventId;
+
+    /**
+     * 사용자 ID
+     */
+    private Long userId;
+
+    /**
+     * 동물 ID
+     */
+    private Long animalId;
+
+    /**
+     * 보상 유형
+     * - ROLLBACK_FAVORITE_ADDED: 찜 추가 롤백 (favorite 삭제)
+     * - ROLLBACK_FAVORITE_REMOVED: 찜 취소 롤백 (favorite 복구)
+     */
+    private String compensationType;
+
+    /**
+     * 실패 원인 (최대 500자)
+     */
+    private String failureReason;
+
+    /**
+     * Factory 메서드: 찜 추가 실패 시 보상 이벤트 생성
+     */
+    public static FavoriteCompensationEvent forAddedFailure(
+            String originalEventId,
+            Long userId,
+            Long animalId,
+            String failureReason
+    ) {
+        return FavoriteCompensationEvent.builder()
+                .eventId(java.util.UUID.randomUUID().toString())
+                .eventType("FAVORITE_COMPENSATION_REQUIRED")
+                .timestamp(LocalDateTime.now())
+                .originalEventId(originalEventId)
+                .userId(userId)
+                .animalId(animalId)
+                .compensationType("ROLLBACK_FAVORITE_ADDED")
+                .failureReason(truncate(failureReason, 500))
+                .build();
+    }
+
+    /**
+     * Factory 메서드: 찜 취소 실패 시 보상 이벤트 생성
+     *
+     * ⚠️ 주의: ROLLBACK_FAVORITE_REMOVED는 실제로 필요 없음!
+     *
+     * 이유:
+     * - user-service는 이미 favorite 삭제 완료 (사용자 의도 달성)
+     * - animal-service는 favoriteCount 감소 실패
+     * - 보상으로 favorite 복구? → 사용자 의도와 반대!
+     * - 정합성은 정기 배치 또는 다음 찜 추가 시 자연스럽게 맞춰짐
+     *
+     * 따라서 이 메서드는 사용하지 않음 (로그만 남김)
+     *
+     * @deprecated 보상 불필요, 사용 금지
+     */
+    @Deprecated
+    public static FavoriteCompensationEvent forRemovedFailure(
+            String originalEventId,
+            Long userId,
+            Long animalId,
+            String failureReason
+    ) {
+        throw new UnsupportedOperationException(
+            "ROLLBACK_FAVORITE_REMOVED is not supported. " +
+            "Compensation for FavoriteRemovedEvent is not needed. " +
+            "favoriteCount will be eventually consistent."
+        );
+    }
+
+    /**
+     * 오류 메시지 길이 제한
+     */
+    private static String truncate(String message, int maxLength) {
+        if (message == null) {
+            return "Unknown error";
+        }
+        return message.length() > maxLength
+                ? message.substring(0, maxLength)
+                : message;
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/event/FavoriteRemovedEvent.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/event/FavoriteRemovedEvent.java
@@ -1,0 +1,21 @@
+package com.pawbridge.animalservice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteRemovedEvent {
+
+    private String eventId;
+    private String eventType;
+    private LocalDateTime timestamp;
+    private Long userId;
+    private Long animalId;
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/handler/FavoriteEventHandler.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/handler/FavoriteEventHandler.java
@@ -1,0 +1,89 @@
+package com.pawbridge.animalservice.handler;
+
+import com.pawbridge.animalservice.entity.ProcessedEvent;
+import com.pawbridge.animalservice.repository.ProcessedEventRepository;
+import com.pawbridge.animalservice.service.AnimalCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Favorite 이벤트 비즈니스 로직 처리 (Delegator 패턴)
+ *
+ * 역할:
+ * - Kafka를 모르는 순수 비즈니스 로직
+ * - @Transactional로 멱등성 체크 + 비즈니스 로직 원자성 보장
+ * - 예외 발생 시 throw → DefaultErrorHandler가 재시도
+ *
+ * 메서드 이름:
+ * - handleXxx (X) - Kafka 용어
+ * - addFavorite, removeFavorite (O) - 비즈니스 의미
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FavoriteEventHandler {
+
+    private final AnimalCommandService animalCommandService;
+    private final ProcessedEventRepository processedEventRepository;
+
+    /**
+     * 찜 추가 처리
+     *
+     * @param eventId  이벤트 ID (멱등성 보장)
+     * @param userId   사용자 ID
+     * @param animalId 동물 ID
+     * @throws Exception 처리 실패 시 (DefaultErrorHandler가 재시도)
+     */
+    @Transactional
+    public void addFavorite(String eventId, Long userId, Long animalId) {
+        log.info("[HANDLER] Adding favorite: eventId={}, userId={}, animalId={}",
+                eventId, userId, animalId);
+
+        // 1. 멱등성 체크 (@Transactional 내부에서 체크 → Race Condition 방지)
+        if (processedEventRepository.existsByEventId(eventId)) {
+            log.warn("[HANDLER] Duplicate event, skipping: eventId={}", eventId);
+            return;  // 중복은 정상 처리로 간주
+        }
+
+        // 2. 비즈니스 로직 실행
+        //    예외 발생 시 트랜잭션 롤백 + throw → DefaultErrorHandler 재시도
+        animalCommandService.incrementFavoriteCount(animalId);
+
+        // 3. 처리 완료 기록 (멱등성)
+        processedEventRepository.save(ProcessedEvent.of(eventId, "FAVORITE_ADDED"));
+
+        log.info("[HANDLER] Successfully added favorite: eventId={}, animalId={}",
+                eventId, animalId);
+    }
+
+    /**
+     * 찜 제거 처리
+     *
+     * @param eventId  이벤트 ID (멱등성 보장)
+     * @param userId   사용자 ID
+     * @param animalId 동물 ID
+     * @throws Exception 처리 실패 시 (DefaultErrorHandler가 재시도)
+     */
+    @Transactional
+    public void removeFavorite(String eventId, Long userId, Long animalId) {
+        log.info("[HANDLER] Removing favorite: eventId={}, userId={}, animalId={}",
+                eventId, userId, animalId);
+
+        // 1. 멱등성 체크
+        if (processedEventRepository.existsByEventId(eventId)) {
+            log.warn("[HANDLER] Duplicate event, skipping: eventId={}", eventId);
+            return;
+        }
+
+        // 2. 비즈니스 로직 실행
+        animalCommandService.decrementFavoriteCount(animalId);
+
+        // 3. 처리 완료 기록
+        processedEventRepository.save(ProcessedEvent.of(eventId, "FAVORITE_REMOVED"));
+
+        log.info("[HANDLER] Successfully removed favorite: eventId={}, animalId={}",
+                eventId, animalId);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/OutboxEventRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/OutboxEventRepository.java
@@ -1,0 +1,39 @@
+package com.pawbridge.animalservice.repository;
+
+import com.pawbridge.animalservice.entity.OutboxEvent;
+import com.pawbridge.animalservice.entity.OutboxEvent.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+
+    /**
+     * 발행 대기 중인 이벤트 조회 (PENDING 상태, 생성 시간 순)
+     * - 스케줄러가 폴링할 때 사용
+     * - 한 번에 최대 100개씩 처리
+     */
+    List<OutboxEvent> findTop100ByStatusOrderByCreatedAtAsc(OutboxStatus status);
+
+    /**
+     * 오래된 발행 완료 이벤트 삭제
+     * - 보관 기간이 지난 이벤트 정리
+     */
+    @Modifying
+    @Query("DELETE FROM OutboxEvent o WHERE o.status = :status AND o.publishedAt < :before")
+    int deleteByStatusAndPublishedAtBefore(
+            @Param("status") OutboxStatus status,
+            @Param("before") LocalDateTime before
+    );
+
+    /**
+     * 상태별 이벤트 수 조회 (모니터링용)
+     */
+    long countByStatus(OutboxStatus status);
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/ProcessedEventRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/ProcessedEventRepository.java
@@ -1,0 +1,27 @@
+package com.pawbridge.animalservice.repository;
+
+import com.pawbridge.animalservice.entity.ProcessedEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface ProcessedEventRepository extends JpaRepository<ProcessedEvent, String> {
+
+    /**
+     * 이벤트 ID로 처리 여부 확인 (멱등성 체크)
+     */
+    boolean existsByEventId(String eventId);
+
+    /**
+     * 오래된 처리 기록 삭제
+     * - 보관 기간이 지난 기록 정리
+     */
+    @Modifying
+    @Query("DELETE FROM ProcessedEvent p WHERE p.processedAt < :before")
+    int deleteByProcessedAtBefore(@Param("before") LocalDateTime before);
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/scheduler/OutboxPublisher.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/scheduler/OutboxPublisher.java
@@ -1,0 +1,119 @@
+package com.pawbridge.animalservice.scheduler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawbridge.animalservice.entity.OutboxEvent;
+import com.pawbridge.animalservice.entity.OutboxEvent.OutboxStatus;
+import com.pawbridge.animalservice.repository.OutboxEventRepository;
+import com.pawbridge.animalservice.service.OutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Outbox 이벤트 발행 스케줄러
+ * - 주기적으로 PENDING 상태의 이벤트를 폴링하여 Kafka로 발행
+ * - 발행 성공 시 PUBLISHED 상태로 변경
+ * - 발행 실패 시 재시도 (최대 3회)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPublisher {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final OutboxService outboxService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final int KAFKA_SEND_TIMEOUT_SECONDS = 10;
+    private static final int DAYS_TO_KEEP_PUBLISHED_EVENTS = 7;
+
+    /**
+     * 1초마다 Outbox 테이블을 폴링하여 이벤트 발행
+     */
+    @Scheduled(fixedDelay = 1000)
+    @Transactional
+    public void publishPendingEvents() {
+        List<OutboxEvent> pendingEvents = outboxEventRepository
+                .findTop100ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
+
+        if (pendingEvents.isEmpty()) {
+            return;
+        }
+
+        log.debug("[OUTBOX-PUBLISHER] Found {} pending events to publish", pendingEvents.size());
+
+        for (OutboxEvent event : pendingEvents) {
+            publishEvent(event);
+        }
+    }
+
+    /**
+     * 단일 이벤트 발행
+     */
+    private void publishEvent(OutboxEvent event) {
+        try {
+            // payload는 이미 JSON 문자열이므로 Object로 역직렬화
+            // JsonSerializer가 다시 직렬화하여 올바른 JSON으로 전송
+            Object eventPayload = objectMapper.readValue(event.getPayload(), Object.class);
+
+            // 동기식 발행 (결과 확인)
+            kafkaTemplate.send(event.getTopic(), event.getAggregateId(), eventPayload)
+                    .get(KAFKA_SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // 발행 성공
+            event.markAsPublished();
+            outboxEventRepository.save(event);
+
+            log.info("[OUTBOX-PUBLISHER] Published event: eventId={}, topic={}, aggregateId={}",
+                    event.getEventId(), event.getTopic(), event.getAggregateId());
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            handlePublishFailure(event, e);
+        } catch (ExecutionException | TimeoutException e) {
+            handlePublishFailure(event, e);
+        } catch (Exception e) {
+            // JSON 파싱 오류 등
+            handlePublishFailure(event, e);
+        }
+    }
+
+    /**
+     * 발행 실패 처리
+     */
+    private void handlePublishFailure(OutboxEvent event, Exception e) {
+        String errorMessage = e.getMessage();
+        if (errorMessage != null && errorMessage.length() > 500) {
+            errorMessage = errorMessage.substring(0, 500);
+        }
+
+        event.markAsFailed(errorMessage);
+        outboxEventRepository.save(event);
+
+        if (event.getStatus() == OutboxStatus.FAILED) {
+            log.error("[OUTBOX-PUBLISHER] Event failed permanently after 3 retries: eventId={}, topic={}, error={}",
+                    event.getEventId(), event.getTopic(), errorMessage);
+        } else {
+            log.warn("[OUTBOX-PUBLISHER] Event publish failed, will retry: eventId={}, retryCount={}, error={}",
+                    event.getEventId(), event.getRetryCount(), errorMessage);
+        }
+    }
+
+    /**
+     * 매일 새벽 3시에 오래된 발행 완료 이벤트 정리
+     */
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void cleanupOldPublishedEvents() {
+        int deletedCount = outboxService.cleanupOldEvents(DAYS_TO_KEEP_PUBLISHED_EVENTS);
+        log.info("[OUTBOX-PUBLISHER] Cleanup completed: {} events deleted", deletedCount);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/OutboxService.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/OutboxService.java
@@ -1,0 +1,91 @@
+package com.pawbridge.animalservice.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawbridge.animalservice.entity.OutboxEvent;
+import com.pawbridge.animalservice.entity.OutboxEvent.OutboxStatus;
+import com.pawbridge.animalservice.repository.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Outbox Pattern 서비스
+ * - 트랜잭션과 함께 이벤트를 저장
+ * - 비즈니스 로직과 같은 트랜잭션에서 호출되어야 함
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Outbox에 이벤트 저장
+     * - 호출하는 메서드의 트랜잭션에 참여
+     * - 비즈니스 로직이 롤백되면 이벤트도 롤백됨
+     *
+     * @param aggregateType Aggregate 타입 (예: "Animal", "Shelter")
+     * @param aggregateId Aggregate ID (예: animalId)
+     * @param eventType 이벤트 타입 (예: "ANIMAL_CREATED")
+     * @param topic Kafka 토픽 이름
+     * @param payload 이벤트 객체
+     * @return 생성된 이벤트 ID
+     */
+    @Transactional
+    public String saveEvent(String aggregateType, String aggregateId, String eventType, String topic, Object payload) {
+        String eventId = UUID.randomUUID().toString();
+
+        try {
+            String payloadJson = objectMapper.writeValueAsString(payload);
+
+            OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .eventId(eventId)
+                    .aggregateType(aggregateType)
+                    .aggregateId(aggregateId)
+                    .eventType(eventType)
+                    .topic(topic)
+                    .payload(payloadJson)
+                    .status(OutboxStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .retryCount(0)
+                    .build();
+
+            outboxEventRepository.save(outboxEvent);
+
+            log.debug("[OUTBOX] Event saved: eventId={}, aggregateType={}, aggregateId={}, eventType={}",
+                    eventId, aggregateType, aggregateId, eventType);
+
+            return eventId;
+
+        } catch (JsonProcessingException e) {
+            log.error("[OUTBOX] Failed to serialize event payload: aggregateType={}, aggregateId={}, error={}",
+                    aggregateType, aggregateId, e.getMessage());
+            throw new RuntimeException("Failed to serialize event payload", e);
+        }
+    }
+
+    /**
+     * 오래된 발행 완료 이벤트 정리
+     * - 7일 이상 지난 PUBLISHED 이벤트 삭제
+     */
+    @Transactional
+    public int cleanupOldEvents(int daysToKeep) {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(daysToKeep);
+        int deletedCount = outboxEventRepository.deleteByStatusAndPublishedAtBefore(
+                OutboxStatus.PUBLISHED, cutoffDate);
+
+        if (deletedCount > 0) {
+            log.info("[OUTBOX] Cleaned up {} old published events (older than {} days)",
+                    deletedCount, daysToKeep);
+        }
+
+        return deletedCount;
+    }
+}

--- a/animal-service/src/main/resources/application.yml
+++ b/animal-service/src/main/resources/application.yml
@@ -33,19 +33,10 @@ spring:
       initialize-schema: always
     job:
       enabled: false
-  # Kafka Settings (Phase 3)
-  # kafka:
-  #   bootstrap-servers: localhost:9092
-  #   producer:
-  #     key-serializer: org.apache.kafka.common.serialization.StringSerializer
-  #     value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-  #   consumer:
-  #     group-id: animal-service
-  #     auto-offset-reset: earliest
-  #     key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-  #     value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-  #     properties:
-  #       spring.json.trusted.packages: com.pawbridge.*
+  # Kafka Settings
+  # Producer/Consumer 상세 설정은 Config 클래스에서 관리
+  kafka:
+    bootstrap-servers: localhost:9092
 
 # Server Settings
 server:


### PR DESCRIPTION
## 변경 사항
 Issue #10 Kafka 연동 개선:
 - 단일 토픽 전략으로 FIFO 순서 보장 (user.favorite.events)
 - Delegator 패턴 적용 (Consumer/Handler 책임 분리)
 - Saga 보상 트랜잭션 구현 (FAVORITE_ADDED 실패 시 rollback)

## 작업 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #10 

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
### 1. 단일 토픽 전략 (user.favorite.events)

**문제**:
- 별도 토픽(user.favorite.added, user.favorite.removed) 사용 시 순서 보장 불가
- favoriteCount는 숫자 필드로 순서가 중요 → 순서 역전 시 count = -1 (오류)

**해결**:
- 단일 토픽 user.favorite.events + 파티션 키 animalId → FIFO 보장
- eventType 필드로 이벤트 구분 (FAVORITE_ADDED / FAVORITE_REMOVED)

### 2. Delegator 패턴 적용

**책임 분리**:
- FavoriteEventConsumer: Kafka 관심사 (파싱, 검증, 라우팅)
- FavoriteEventHandler: 비즈니스 로직 (@Transactional)

**장점**:
- 관심사 분리, @Transactional 경계 명확화, 단위 테스트 용이성

### 3. Saga 보상 트랜잭션

**보상 전략**:
- FAVORITE_ADDED 실패 → user-service가 favorite 레코드 삭제
- FAVORITE_REMOVED 실패 → 보상 불필요 (Eventually Consistent)

**Recoverer 구현**:
- DefaultErrorHandler에 람다로 구현
- 재시도 3회 실패 시 보상 이벤트 발행 (user.compensation.events)
- try-catch로 FATAL-ERROR 처리 (Consumer 블로킹 방지)

### 4. 변경된 파일

**신규**:
- FavoriteCompensationEvent.java - 보상 트랜잭션 이벤트
- handler/FavoriteEventHandler.java - 비즈니스 로직 Handler

**수정**:
- KafkaConsumerConfig.java - Recoverer 추가
- FavoriteEventConsumer.java - 단일 리스너 + switch 분기
