### PR TITLE
feat: V1.0 초기 배포 환경 구축 및 CI/CD 파이프라인 적용

### DIFF
--- a/.github/workflows/deploy-animal.yml
+++ b/.github/workflows/deploy-animal.yml
@@ -1,0 +1,63 @@
+name: Deploy Animal Service
+
+on:
+  push:
+    branches: [ "dev" ]
+    paths:
+      - 'animal-service/**' # 이 폴더가 변했을 때만 실행!
+      - '.github/workflows/deploy-animal.yml'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 1. 빌드 (해당 폴더로 이동해서 실행)
+      - name: Build Animal Service
+        run: |
+          cd animal-service  # 해당 서비스 폴더로 이동
+          chmod +x gradlew
+          ./gradlew clean build -x test
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # 2. 이미지 빌드 & 푸시
+      - name: Build & Push Docker Image
+        run: |
+          cd animal-service
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/animal-service:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/animal-service:latest
+
+      # 3. 배포 (Node-3로 전송)
+      - name: Deploy to Node-3
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST_3 }} # Animal은 Node-3
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/deploy
+            # 환경변수 주입 (필요한 경우)
+            echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
+            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+            echo "APMS_KEY=${{ secrets.APMS_KEY }}" >> .env
+            
+            # 프라이빗 IP 주입
+            echo "NODE1_PRIVATE_IP=${{ secrets.NODE1_PRIVATE_IP }}" >> .env
+            echo "NODE2_PRIVATE_IP=${{ secrets.NODE2_PRIVATE_IP }}" >> .env
+            echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
+            
+            # 해당 서비스만 콕 집어서 재시작
+            docker compose pull animal-service
+            docker compose up -d --no-deps animal-service
+            docker image prune -f

--- a/.github/workflows/deploy-discovery.yml
+++ b/.github/workflows/deploy-discovery.yml
@@ -1,0 +1,62 @@
+name: Deploy Animal Service
+
+on:
+  push:
+    branches: [ "dev" ]
+    paths:
+      - 'discovery-service/**' # 이 폴더가 변했을 때만 실행!
+      - '.github/workflows/deploy-discovery.yml'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 1. 빌드 (해당 폴더로 이동해서 실행)
+      - name: Build Discovery Service
+        run: |
+          cd discovery-service  # 해당 서비스 폴더로 이동
+          chmod +x gradlew
+          ./gradlew clean build -x test
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # 2. 이미지 빌드 & 푸시
+      - name: Build & Push Docker Image
+        run: |
+          cd discovery-service
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/discovery-service:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/discovery-service:latest
+
+      # 3. 배포 (Node-1로 전송)
+      - name: Deploy to Node-3
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST_1 }} # Discovery는 Node-1
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/deploy
+            # 환경변수 주입 (필요한 경우)
+            echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+            
+            # 프라이빗 IP 주입
+            echo "NODE1_PRIVATE_IP=${{ secrets.NODE1_PRIVATE_IP }}" >> .env
+            echo "NODE2_PRIVATE_IP=${{ secrets.NODE2_PRIVATE_IP }}" >> .env
+            echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
+            
+            # 해당 서비스만 콕 집어서 재시작
+            docker compose pull discovery-service
+            docker compose up -d --no-deps discovery-service
+            docker image prune -f

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -1,0 +1,62 @@
+name: Deploy Animal Service
+
+on:
+  push:
+    branches: [ "dev" ]
+    paths:
+      - 'api-gateway/**' # 이 폴더가 변했을 때만 실행!
+      - '.github/workflows/deploy-gateway.yml'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 1. 빌드 (해당 폴더로 이동해서 실행)
+      - name: Build Gateway Service
+        run: |
+          cd api-gateway  # 해당 서비스 폴더로 이동
+          chmod +x gradlew
+          ./gradlew clean build -x test
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # 2. 이미지 빌드 & 푸시
+      - name: Build & Push Docker Image
+        run: |
+          cd api-gateway
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/api-gateway:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/api-gateway:latest
+
+      # 3. 배포 (Node-1로 전송)
+      - name: Deploy to Node-3
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST_1 }} # Gateway는 Node-1
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/deploy
+            # 환경변수 주입 (필요한 경우)
+            echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+            
+            # 프라이빗 IP 주입
+            echo "NODE1_PRIVATE_IP=${{ secrets.NODE1_PRIVATE_IP }}" >> .env
+            echo "NODE2_PRIVATE_IP=${{ secrets.NODE2_PRIVATE_IP }}" >> .env
+            echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
+            
+            # 해당 서비스만 콕 집어서 재시작
+            docker compose pull api-gateway
+            docker compose up -d --no-deps api-gateway
+            docker image prune -f

--- a/.github/workflows/deploy-user.yml
+++ b/.github/workflows/deploy-user.yml
@@ -1,0 +1,81 @@
+name: Deploy Animal Service
+
+on:
+  push:
+    branches: [ "dev" ]
+    paths:
+      - 'user-service/**' # 이 폴더가 변했을 때만 실행!
+      - '.github/workflows/deploy-user.yml'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 1. 빌드 (해당 폴더로 이동해서 실행)
+      - name: Build User Service
+        run: |
+          cd user-service  # 해당 서비스 폴더로 이동
+          chmod +x gradlew
+          ./gradlew clean build -x test
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # 2. 이미지 빌드 & 푸시
+      - name: Build & Push Docker Image
+        run: |
+          cd user-service
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/user-service:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/user-service:latest
+
+      # 3. 배포 (Node-2로 전송)
+      - name: Deploy to Node-3
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST_2 }} # User는 Node-2
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/deploy
+            echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
+            echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
+            echo "MYSQL_ROOT_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+            
+            # JWT
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+            echo "JWT_ACCESS_TOKEN_EXPIRATION=${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION }}" >> .env
+            echo "JWT_REFRESH_TOKEN_EXPIRATION=${{ secrets.JWT_REFRESH_TOKEN_EXPIRATION }}" >> .env
+            
+            # OAuth
+            echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env
+            echo "GOOGLE_SECRET_KEY=${{ secrets.GOOGLE_SECRET_KEY }}" >> .env
+            echo "REDIRECT_URI=${{ secrets.REDIRECT_URI }}" >> .env
+            echo "OAUTH2_REDIRECT_URI=${{ secrets.OAUTH2_REDIRECT_URI }}" >> .env
+            
+            # Email (변수명 변환!)
+            echo "GOOGLE_EMAIL=${{ secrets.MAIL_USERNAME }}" >> .env
+            echo "GOOGLE_EMAIL_SECRET_KEY=${{ secrets.MAIL_PASSWORD }}" >> .env
+            
+            # DB_USER_URL 정의: Node-2 내부 DB(mysql) 연결 주소
+            echo "DB_USER_URL=jdbc:mysql://mysql:3306/pawbridge_user?useSSL=false&allowPublicKeyRetrieval=true" >> .env
+            
+            # 프라이빗 IP 주입
+            echo "NODE1_PRIVATE_IP=${{ secrets.NODE1_PRIVATE_IP }}" >> .env
+            echo "NODE2_PRIVATE_IP=${{ secrets.NODE2_PRIVATE_IP }}" >> .env
+            echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
+            
+            # 실행
+            docker compose pull user-service
+            docker compose up -d --no-deps user-service
+            docker image prune -f

--- a/animal-service/Dockerfile
+++ b/animal-service/Dockerfile
@@ -1,0 +1,9 @@
+# Java 17 버전의 가벼운 리눅스 환경 사용
+FROM openjdk:17-jdk-slim
+
+# 빌드된 Jar 파일을 app.jar로 복사
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+# 실행 명령어
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,9 @@
+# Java 17 버전의 가벼운 리눅스 환경 사용
+FROM openjdk:17-jdk-slim
+
+# 빌드된 Jar 파일을 app.jar로 복사
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+# 실행 명령어
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/discovery-service/Dockerfile
+++ b/discovery-service/Dockerfile
@@ -1,0 +1,9 @@
+# Java 17 버전의 가벼운 리눅스 환경 사용
+FROM openjdk:17-jdk-slim
+
+# 빌드된 Jar 파일을 app.jar로 복사
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+# 실행 명령어
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,9 @@
+# Java 17 버전의 가벼운 리눅스 환경 사용
+FROM openjdk:17-jdk-slim
+
+# 빌드된 Jar 파일을 app.jar로 복사
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+# 실행 명령어
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
## 변경 사항
AWS EC2 3-Node 환경을 구성하고, GitHub Actions를 통해 서비스별로 독립적인 무중단 배포 파이프라인을 구축

### 인프라 및 CI/CD
- AWS EC2 3-Node 분산 아키텍처 환경 변수 매핑을 완료했습니다.
- Gateway, Discovery, User, Animal 서비스에 대한 Docker Image 빌드 및 푸시 워크플로우를 생성했습니다.
- deploy-*.yml 스크립트를 통해 EC2에 SSH 접속 후 docker compose pull & up -d를 수행하도록 자동화했습니다.
- 비용 효율성을 위해 DB(Node-2)와 Kafka(Node-3)를 물리적으로 분리했습니다.

### 애플리케이션 (코드 수정)
- Redis 의존성을 user-service에 추가하여 이메일 인증 통합을 준비했습니다.
- api-gateway, discovery-service, user-service, animal-service 4개 서비스의 Dockerfile을 생성했습니다.
- user-service의 DB 연결 변수명을 **DB_URL에서 DB_USER_URL**로 변경했습니다.

## 작업 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #18 

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
### 아키텍처 의사결정 요약 (리뷰어 참고)
1. 비용 절감: t3.large 대신 t3.micro/small 3대를 분산 배치하여 AWS 크레딧 소모율을 최소화했습니다.
2. 리소스 분리: **Node-2(Core)**는 MySQL을, **Node-3(Event)**는 Kafka/Zookeeper를 담당하도록 분리하여, 서로 간의 디스크 I/O 및 메모리 경합을 막았습니다.
3. V2 확장 대비: 추후 Elasticsearch를 추가하게 되면, Node-4를 t3.small로 추가하여 **수평적 확장(Scale-out)**할 수 있도록 설계했습니다.
