### PR TITLE
fix: deploy-user.yml에 MYSQL_ROOT_PASSWORD 환경변수 추가

### DIFF
--- a/.github/workflows/deploy-user.yml
+++ b/.github/workflows/deploy-user.yml
@@ -49,7 +49,7 @@ jobs:
             cd ~/deploy
             echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
             echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
-            echo "MYSQL_ROOT_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+            echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> .env
             echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
             
             # JWT


### PR DESCRIPTION
## 변경 사항
- deploy-user.yml에 MYSQL_ROOT_PASSWORD 환경변수 추가
- Node-2의 MySQL 컨테이너 정상 시작을 위한 필수 환경변수 설정

## 작업 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈

<!-- 관련된 Issue 번호를 작성해주세요 -->
Related to #18 

## 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
AWS 배포 시 Node-2의 MySQL 컨테이너가 시작되지 않는 문제 해결. docker-compose.yml에서 `${MYSQL_ROOT_PASSWORD}` 환경변수를 참조하지만, GitHub Actions 워크플로우에서 해당 변수를 .env에 추가하지 않아 발생한 문제.
