### PR TITLE
feat: MSA 인프라 구축 (Discovery Service + Gateway 연동)

### DIFF
--- a/animal-service/build.gradle
+++ b/animal-service/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/animal-service/src/main/java/com/pawbridge/animalservice/controller/AnimalController.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/controller/AnimalController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.*;
  * - Controller는 요청 받고 Facade에 전달, 응답 반환만 담당
  */
 @RestController
-@RequestMapping("/api/animals")
+@RequestMapping("/api/v1/animals")
 @RequiredArgsConstructor
 public class AnimalController {
 

--- a/animal-service/src/main/java/com/pawbridge/animalservice/controller/BatchController.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/controller/BatchController.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/batch")
+@RequestMapping("/api/v1/batch")
 @RequiredArgsConstructor
 public class BatchController {
 

--- a/animal-service/src/main/java/com/pawbridge/animalservice/controller/ShelterController.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/controller/ShelterController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
  * - Controller는 요청 받고 Facade에 전달, 응답 반환만 담당
  */
 @RestController
-@RequestMapping("/api/shelters")
+@RequestMapping("/api/v1/shelters")
 @RequiredArgsConstructor
 public class ShelterController {
 

--- a/animal-service/src/main/java/com/pawbridge/animalservice/document/AnimalDocument.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/document/AnimalDocument.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
  * - Animal 엔티티와 동일한 구조 유지
  * - Shelter 정보는 비정규화하여 포함
  */
-@Document(indexName = "animal.animals")
+@Document(indexName = "animal.pawbridge_animal.animals")
 @Getter
 @Builder
 @NoArgsConstructor

--- a/animal-service/src/main/resources/application.yml
+++ b/animal-service/src/main/resources/application.yml
@@ -92,3 +92,14 @@ batch:
       # 0 0 */6 * * ? : 6시간마다
       # 0 */30 * * * ? : 30분마다 (테스트용)
       cron: "0 0 2 * * ?"
+
+# Eureka Client
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${server.port}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -10,27 +10,44 @@ spring:
       routes:
         # OAuth2 경로 (JWT 필터 제외, 우선순위 높음)
         - id: user-service-oauth2
-          uri: ${USER_SERVICE_URL:http://localhost:8081}
+          uri: lb://user-service
           predicates:
             - Path=/oauth2/authorization/**, /login/oauth2/code/**
 
         # Email 경로 (JWT 필터 제외 - 회원가입 전, user-service로 라우팅)
         - id: user-service-email
-          uri: ${USER_SERVICE_URL:http://localhost:8081}
+          uri: lb://user-service
           predicates:
             - Path=/api/email/**
 
         # User Service (JWT 필터 적용, 화이트리스트는 필터 내부에서 처리)
         - id: user-service
-          uri: ${USER_SERVICE_URL:http://localhost:8081}
+          uri: lb://user-service
           predicates:
             - Path=/api/v1/users/**, /api/v1/auth/**
           filters:
             - JwtAuthorization
 
+        # Animal Service - 조회 (GET, 공개)
+        - id: animal-service-public
+          uri: lb://animal-service
+          predicates:
+            - Path=/api/v1/animals/**
+            - Method=GET
+          # JWT 필터 없음 (로그인 없이 검색/조회 가능)
+
+        # Animal Service - CUD (POST/PUT/PATCH/DELETE, 인증 필요)
+        - id: animal-service-protected
+          uri: lb://animal-service
+          predicates:
+            - Path=/api/v1/animals/**, /api/v1/shelters/**, /api/v1/batch/**
+            - Method=POST,PUT,PATCH,DELETE
+          filters:
+            - JwtAuthorization
+
         # Community Service (JWT 필터 적용)
         - id: community-service
-          uri: http://localhost:8089
+          uri: lb://community-service
           predicates:
             - Path=/api/v1/posts/**, /api/v1/comments/**
           filters:
@@ -66,11 +83,18 @@ spring:
               - Authorization              # 응답 헤더 노출
             allowCredentials: false        # 개발 단계에서는 false
 
-# Eureka (현재 사용 안 함)
+# Eureka Client
 eureka:
   client:
-    enabled: false
+    enabled: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${server.port}
 
 # JWT
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:your-secret-key-for-development-at-least-256-bits-long-secret-key-here}

--- a/community-service/build.gradle
+++ b/community-service/build.gradle
@@ -24,11 +24,16 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2024.0.2")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka'
@@ -50,6 +55,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/community-service/src/main/resources/application.yml
+++ b/community-service/src/main/resources/application.yml
@@ -41,3 +41,14 @@ spring:
         static: ${S3_REGION:ap-northeast-2}
       s3:
         bucket: ${S3_BUCKET_NAME}
+
+# Eureka Client
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${server.port}

--- a/discovery-service/src/main/java/com/pawbridge/discoveryservice/DiscoveryServiceApplication.java
+++ b/discovery-service/src/main/java/com/pawbridge/discoveryservice/DiscoveryServiceApplication.java
@@ -2,7 +2,9 @@ package com.pawbridge.discoveryservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
+@EnableEurekaServer
 @SpringBootApplication
 public class DiscoveryServiceApplication {
 

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8761
+
+spring:
+  application:
+    name: discovery-service
+
+eureka:
+  client:
+    register-with-eureka: false     # Do not register itself
+    fetch-registry: false            # Do not fetch registry
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  server:
+    enable-self-preservation: false  # Disable self-preservation for development
+    eviction-interval-timer-in-ms: 3000  # Eviction interval (3 seconds)

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -24,6 +24,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2024.0.2")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -33,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
@@ -44,6 +49,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -61,3 +61,14 @@ jwt:
 
 oauth2:
   redirect-uri: ${OAUTH2_REDIRECT_URI}
+
+# Eureka Client
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${server.port}


### PR DESCRIPTION
## 변경 사항
PawBridge의 마이크로서비스 아키텍처 완성을 위해 **Service Discovery(Eureka)**를 도입하고, **API Gateway**가 이를 통해 서비스를 동적으로 라우팅하도록 인프라를
구축했습니다.

 ### 주요 작업 내용
1.  **Discovery Service (Eureka Server) 구축**
     *   `discovery-service` 구현 및 8761 포트 활성화
     *   Self-Preservation 모드 설정 (개발 환경 최적화)

2.  **마이크로서비스 연동 (Eureka Client 적용)**
     *   대상: `animal-service`, `user-service`, `community-service`
     *   각 서비스에 `eureka-client` 의존성 추가 및 설정 적용
     *   **API 경로 표준화**: `animal-service`의 모든 API 경로를 `/api/v1/**` 패턴으로 통일

3.  **API Gateway 고도화**
     *   하드코딩된 라우팅 주소(`http://localhost:xxxx`) 제거
     *   `lb://SERVICE-NAME` 방식을 통한 LoadBalancer 기반 동적 라우팅 적용
     *   User, Community, Animal 서비스 라우팅 규칙 재정비

 ## 작업 유형
 - [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈

Closes #28

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
### 테스트 및 검증 방법
1.  `infrastructure/start-all.sh` 실행 (DB, Kafka 등)
2.  `discovery-service` 실행 → `http://localhost:8761` 대시보드 확인
3.  각 서비스(`user`, `animal`, `community`) 실행
4.  `api-gateway` 실행
5.  **결과 확인**: Eureka 대시보드에 4개 서비스가 모두 `UP` 상태로 등록되어야 하며, Gateway(`:8080`)를 통한 API 호출이 정상 작동해야 합니다.