### PR TITLE
fix: Config Service 빌드 오류 해결을 위한 Dockerfile 베이스 이미지 변경 (openjdk -> ec…

### DIFF
--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
## 🚑 Hotfix
- Config Service 빌드 실패(`openjdk:17-jdk-slim not found`) 해결을 위해 베이스 이미지를 `eclipse-temurin:17-jdk-jammy`로 변경함.