### PR TITLE
fix: Config Service 빌드 오류 수정 및 컨테이너 무한 재시작 방지 (CPU 100% 해결)

### DIFF
--- a/deployment/docker-compose-node-1.yml
+++ b/deployment/docker-compose-node-1.yml
@@ -17,7 +17,10 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 2. API Gateway
   api-gateway:
@@ -35,7 +38,10 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 3. Redis (Global Cache)
   redis:
@@ -43,7 +49,10 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 4. Zipkin (Distributed Tracing)
   zipkin:
@@ -51,7 +60,10 @@ services:
     container_name: zipkin
     ports:
       - "9411:9411"
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 5. Prometheus
   prometheus:
@@ -61,7 +73,10 @@ services:
       - "9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 6. Grafana
   grafana:
@@ -69,7 +84,10 @@ services:
     container_name: grafana
     ports:
       - "3000:3000"
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 7. Nginx (Optional: In front of Gateway)
   # 7. Nginx (HTTPS Proxy)
@@ -84,7 +102,10 @@ services:
       - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       - api-gateway
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
 volumes:
   redis_data:

--- a/deployment/docker-compose-node-2.yml
+++ b/deployment/docker-compose-node-2.yml
@@ -19,7 +19,10 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 2. MySQL (Main DB)
   mysql:
@@ -32,7 +35,10 @@ services:
       - MYSQL_DATABASE=pawbridge
     volumes:
       - mysql_data:/var/lib/mysql
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 3. Kibana (Logs/Monitoring)
   kibana:
@@ -42,7 +48,10 @@ services:
       - "5601:5601"
     environment:
       - ELASTICSEARCH_HOSTS=http://${NODE5_PRIVATE_IP}:9200
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
 volumes:
   mysql_data:

--- a/deployment/docker-compose-node-3.yml
+++ b/deployment/docker-compose-node-3.yml
@@ -10,7 +10,10 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 2. Kafka
   kafka:
@@ -26,7 +29,10 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     depends_on:
       - zookeeper
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 3. Animal Service
   animal-service:
@@ -44,4 +50,7 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5

--- a/deployment/docker-compose-node-4.yml
+++ b/deployment/docker-compose-node-4.yml
@@ -17,7 +17,10 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 2. Community Service
   community-service:
@@ -35,7 +38,10 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 3. Store Service
   store-service:
@@ -53,7 +59,10 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 4. Payment Service
   payment-service:
@@ -71,4 +80,7 @@ services:
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}
       - NODE5_PRIVATE_IP=${NODE5_PRIVATE_IP}
       - EC2_HOST_1=${EC2_HOST_1}
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5

--- a/deployment/docker-compose-node-5.yml
+++ b/deployment/docker-compose-node-5.yml
@@ -13,7 +13,10 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx1000m"
     volumes:
       - es_data:/usr/share/elasticsearch/data
-    restart: always
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
   # 2. Kafka Connect (Optional - if needed for CDC)
   # kafka-connect:


### PR DESCRIPTION
## Hotfix
**CPU 과부하 방지 및 서비스 안정화**
- 기존 `restart: always` (무한 재시도) 제거
- `deploy.restart_policy` 적용: 실패 시 **최대 5회**까지만 재시도하도록 변경 (`max_attempts: 5`)

적용 대상: Node 1, 2, 3, 4 5 전체 Docker Compose 파일.