### PR TITLE
feat: 인프라 고도화 (Node 5 통합 배포 및 전체 안정화)

### DIFF
--- a/.github/workflows/deploy-animal.yml
+++ b/.github/workflows/deploy-animal.yml
@@ -86,7 +86,7 @@ jobs:
             echo "NODE2_PRIVATE_IP=${{ secrets.NODE2_PRIVATE_IP }}" >> .env
             echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
             
-            # 해당 서비스만 콕 집어서 재시작
+            # Node 3 전체 서비스(Kafka, Zookeeper 포함) 상태 확인 및 재시작
             docker compose pull animal-service
-            docker compose up -d --no-deps animal-service
+            docker compose up -d
             docker image prune -f

--- a/.github/workflows/deploy-elastic-connect.yml
+++ b/.github/workflows/deploy-elastic-connect.yml
@@ -1,0 +1,76 @@
+name: Deploy Elastic & Connect
+
+on:
+  push:
+    branches: [ "dev" ]
+    paths:
+      - 'infrastructure/elasticsearch/**'
+      - 'infrastructure/kafka/**'
+      - '.github/workflows/deploy-elastic-connect.yml'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build & Push Elasticsearch (Nori)
+        run: |
+          cd infrastructure/elasticsearch
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/elasticsearch-nori:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/elasticsearch-nori:latest
+
+      - name: Build & Push Kafka Connect
+        run: |
+          cd infrastructure/kafka
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/kafka-connect:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/kafka-connect:latest
+
+      # SCP: docker-compose-node-5.yml 전송
+      - name: Copy Docker Compose to Node-5
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST_5 }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          source: "deployment/docker-compose-node-5.yml"
+          target: "~/deploy"
+          strip_components: 1
+
+      # SCP: infrastructure 폴더 전송 (CDC 설정용)
+      - name: Copy Infrastructure to Node-5
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST_5 }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          source: "infrastructure"
+          target: "~/deploy"
+
+      # SSH: 배포 실행
+      - name: Deploy to Node-5
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST_5 }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/deploy
+            mv docker-compose-node-5.yml docker-compose.yml
+
+            # 환경변수 설정
+            echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
+            
+            # Node 3 (Kafka), Node 5 (ES) Private IPs
+            echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
+            echo "NODE5_PRIVATE_IP=${{ secrets.NODE5_PRIVATE_IP }}" >> .env
+
+            docker compose pull
+            docker compose up -d
+            docker image prune -f

--- a/animal-service/src/main/java/com/pawbridge/animalservice/AnimalServiceApplication.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/AnimalServiceApplication.java
@@ -10,4 +10,5 @@ public class AnimalServiceApplication {
 		SpringApplication.run(AnimalServiceApplication.class, args);
 	}
 
+
 }

--- a/api-gateway/src/main/java/com/pawbridge/apigateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/ApiGatewayApplication.java
@@ -10,4 +10,5 @@ public class ApiGatewayApplication {
 		SpringApplication.run(ApiGatewayApplication.class, args);
 	}
 
+
 }

--- a/community-service/src/main/java/com/pawbridge/communityservice/CommunityServiceApplication.java
+++ b/community-service/src/main/java/com/pawbridge/communityservice/CommunityServiceApplication.java
@@ -12,4 +12,5 @@ public class CommunityServiceApplication {
 		SpringApplication.run(CommunityServiceApplication.class, args);
 	}
 
+
 }

--- a/config-service/src/main/java/com/pawbridge/configservice/ConfigServiceApplication.java
+++ b/config-service/src/main/java/com/pawbridge/configservice/ConfigServiceApplication.java
@@ -12,4 +12,5 @@ public class ConfigServiceApplication {
 		SpringApplication.run(ConfigServiceApplication.class, args);
 	}
 
+
 }

--- a/deployment/docker-compose-node-5.yml
+++ b/deployment/docker-compose-node-5.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # 1. Elasticsearch
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    image: ${DOCKER_USERNAME}/elasticsearch-nori:latest
     container_name: elasticsearch
     ports:
       - "9200:9200"
@@ -18,10 +18,32 @@ services:
         condition: on-failure
         max_attempts: 5
 
-  # 2. Kafka Connect (Optional - if needed for CDC)
-  # kafka-connect:
-  #   image: confluentinc/cp-kafka-connect:7.4.0
-  #   ...
+  # 2. Kafka Connect (CDC)
+  kafka-connect:
+    image: ${DOCKER_USERNAME}/kafka-connect:latest
+    container_name: kafka-connect
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: "${NODE3_PRIVATE_IP}:9092"
+      CONNECT_REST_ADVERTISED_HOST_NAME: "kafka-connect"
+      CONNECT_GROUP_ID: "compose-connect-group"
+      CONNECT_CONFIG_STORAGE_TOPIC: "docker-connect-configs"
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
+      CONNECT_OFFSET_STORAGE_TOPIC: "docker-connect-offsets"
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_TOPIC: "docker-connect-status"
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_REST_PORT: 8083
+    deploy:
+      restart_policy:
+        condition: on-failure
+        max_attempts: 5
 
 volumes:
   es_data:

--- a/discovery-service/src/main/java/com/pawbridge/discoveryservice/DiscoveryServiceApplication.java
+++ b/discovery-service/src/main/java/com/pawbridge/discoveryservice/DiscoveryServiceApplication.java
@@ -12,4 +12,5 @@ public class DiscoveryServiceApplication {
 		SpringApplication.run(DiscoveryServiceApplication.class, args);
 	}
 
+
 }

--- a/infrastructure/elasticsearch/Dockerfile
+++ b/infrastructure/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.0
 
 # nori 한국어 형태소 분석 플러그인 설치
 RUN elasticsearch-plugin install analysis-nori

--- a/infrastructure/kafka/Dockerfile
+++ b/infrastructure/kafka/Dockerfile
@@ -1,16 +1,7 @@
-# Confluent Kafka Connect + Debezium MySQL Connector + Elasticsearch Sink Connector
 FROM confluentinc/cp-kafka-connect:7.5.0
 
-USER root
+# Install Debezium MySQL Connector
+RUN confluent-hub install --no-prompt debezium/debezium-connector-mysql:2.2.1
 
-# 1. Debezium MySQL Connector 수동 다운로드 및 설치 (Maven Central)
-RUN curl -L https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/2.4.0.Final/debezium-connector-mysql-2.4.0.Final-plugin.tar.gz \
-    -o /tmp/debezium-mysql.tar.gz && \
-    mkdir -p /usr/share/confluent-hub-components/debezium-mysql && \
-    tar -xzf /tmp/debezium-mysql.tar.gz -C /usr/share/confluent-hub-components/debezium-mysql --strip-components=1 && \
-    rm /tmp/debezium-mysql.tar.gz
-
-# 2. Elasticsearch Sink Connector 설치 (버전 latest 사용)
-RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:latest
-
-USER appuser
+# Install Elasticsearch Sink Connector
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-elasticsearch:14.0.0

--- a/infrastructure/setup_prod_cdc.sh
+++ b/infrastructure/setup_prod_cdc.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# =================================================================
+# [PawBridge] CDC & Elasticsearch Production Setup Script (Node 5)
+# =================================================================
+
+# 1. 환경 변수 확인
+if [ -z "$NODE2_DB_IP" ] || [ -z "$NODE3_KAFKA_IP" ]; then
+    echo "❌ 에러: NODE2_DB_IP 또는 NODE3_KAFKA_IP 환경변수가 설정되지 않았습니다."
+    echo "   사용법: export NODE2_DB_IP=... export NODE3_KAFKA_IP=... && ./setup_prod_cdc.sh"
+    exit 1
+fi
+
+CONNECT_URL="http://localhost:8083/connectors"
+ES_URL="http://localhost:9200"
+
+echo "🚀 CDC 프로덕션 설정 시작..."
+echo "   - DB(Node 2): $NODE2_DB_IP"
+echo "   - Kafka(Node 3): $NODE3_KAFKA_IP"
+echo "   - Connect: $CONNECT_URL"
+echo ""
+
+# 2. Elasticsearch 인덱스 설정 (Nori 적용)
+echo "🔍 1. Elasticsearch 인덱스 설정 (setup-index.sh 실행)..."
+chmod +x ./elasticsearch/setup-index.sh
+cd elasticsearch
+./setup-index.sh
+cd ..
+echo ""
+
+# 3. Connector 등록 함수
+register_connector() {
+    local NAME=$1
+    local FILE=$2
+    
+    echo "🔨 Connector 등록 중: $NAME"
+    
+    # JSON 파일 읽어서 변수 치환 (envsubst 대신 sed 사용 - 호환성)
+    # db-server -> NODE2_DB_IP
+    # kafka-broker -> NODE3_KAFKA_IP
+    # localhost -> NODE3_KAFKA_IP (for bootstrap)
+    
+    CONFIG_CONTENT=$(cat $FILE)
+    CONFIG_CONTENT=${CONFIG_CONTENT//db-server/$NODE2_DB_IP}
+    CONFIG_CONTENT=${CONFIG_CONTENT//kafka-broker/$NODE3_KAFKA_IP}
+    CONFIG_CONTENT=${CONFIG_CONTENT//29092/9092} # Port 변경
+    
+    # 등록 요청
+    RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" -d "$CONFIG_CONTENT" "$CONNECT_URL")
+    
+    echo "   결과: $RESPONSE"
+}
+
+# 4. Connector 등록 실행
+echo "🔍 2. Kafka Connectors 등록..."
+
+# 4-1. MySQL Source Connector
+register_connector "animal-animals-connector" "./kafka/connectors/animal-animals-connector.json"
+
+# 4-2. Elasticsearch Sink Connector
+register_connector "elasticsearch-sink-v3" "./kafka/connectors/elasticsearch-sink-connector-v3.json"
+
+echo ""
+echo "🎉 모든 설정 요청 완료! (http://(Node5_Public_IP):8083/connectors 에서 확인 가능)"

--- a/payment-service/src/main/java/com/pawbridge/paymentservice/PaymentServiceApplication.java
+++ b/payment-service/src/main/java/com/pawbridge/paymentservice/PaymentServiceApplication.java
@@ -12,4 +12,5 @@ public class PaymentServiceApplication {
 		SpringApplication.run(PaymentServiceApplication.class, args);
 	}
 
+
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/StoreServiceApplication.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/StoreServiceApplication.java
@@ -15,4 +15,5 @@ public class StoreServiceApplication {
 		SpringApplication.run(StoreServiceApplication.class, args);
 	}
 
+
 }

--- a/user-service/src/main/java/com/pawbridge/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/pawbridge/userservice/UserServiceApplication.java
@@ -19,4 +19,5 @@ public class UserServiceApplication {
 		SpringApplication.run(UserServiceApplication.class, args);
 	}
 
+
 }


### PR DESCRIPTION
## 변경 사항
- **Node 5 통합 배포 파이프라인 구축:**
    - deploy-elastic-connect.yml 워크플로우를 신설했습니다.
    - Elasticsearch(Nori Plugin)와 Kafka Connect(Debezium, ES Sink)를 하나의 파이프라인으로 통합 관리합니다.
    - infrastructure/ 폴더 내 변경 사항 발생 시 자동으로 Node 5에 배포됩니다.
- **CDC 자동화:** setup_prod_cdc.sh 스크립트를 추가하여 프로덕션 환경에서 원클릭으로 커넥터를 등록할 수 있도록 했습니다.
- **배포 프로세스 개선:**
    - deploy-animal.yml로직을 수정하여(up -d), Kafka 등 인프라 설정 변경 시에도 자동으로 적용되도록 개선했습니다.

## 작업 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #60 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함 ("변경 사항 없음"으로 인한 배포 Skip은 정상 동작임)
- [x] 코드 스타일 가이드를 따름
- [ ] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- **Node 3 배포 주의:** Animal Service 배포 시 Kafka 설정이 변경되었다면 Kafka도 일시적으로 재시작될 수 있습니다. (설정 변경이 없다면 서비스 중단 없음)
- **Node 5 배포 후:** 최초 1회 setup_prod_cdc.sh 실행이 필요