### PR TITLE
fix: Animal Service 무한 재시작 원인 제거 (spring-dotenv 삭제 및 Batch 차단)

### DIFF
--- a/animal-service/build.gradle
+++ b/animal-service/build.gradle
@@ -29,7 +29,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/deployment/docker-compose-node-3.yml
+++ b/deployment/docker-compose-node-3.yml
@@ -48,6 +48,7 @@ services:
       - SPRING_SQL_INIT_MODE=never
       - SPRING_BATCH_JDBC_INITIALIZE_SCHEMA=never
       - SPRING_BATCH_JOB_ENABLED=false
+      - SPRING_AUTOCONFIGURE_EXCLUDE=org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
       - NODE1_PRIVATE_IP=${NODE1_PRIVATE_IP}
       - NODE2_PRIVATE_IP=${NODE2_PRIVATE_IP}
       - NODE3_PRIVATE_IP=${NODE3_PRIVATE_IP}


### PR DESCRIPTION
긴급 수정 (Hotfix V3)
Animal Service가 배포 후 시작 단계에서 failed to determine DatabaseDriver 에러를 내며 반복적으로 죽는 치명적인 문제를 해결

원인 분석 (Root Cause)
1. Dependency 충돌: 정상 작동하는 타 서비스(Payment)와 달리, Animal Service에는 spring-dotenv 라이브러리가 포함
이 라이브러리가 초기화 단계에서 Environment 로딩 순서에 개입하여, Config Server에서 받아온 DB 비밀번호 설정을 덮어쓰거나 누락시키는 현상을 유발
3. Spring Batch Eager Init: Spring Boot 3.x에서 Spring Batch의 자동 설정(BatchDataSourceScriptDatabaseInitializer)이 예상보다 강력하게 동작, 단순 프로퍼티(never)만으로는 비활성화가 되지 않음

변경 사항
1. animal-service/build.gradle 
spring-dotenv 의존성 제거: Config Server의 프로퍼티 로딩을 방해하는 요소를 원천 제거하여, 순수하게 Config Server 값만 사용하도록 복구

2. docker-compose-node-3.yml
Batch AutoConfiguration 제외: 환경변수 SPRING_AUTOCONFIGURE_EXCLUDE를 사용하여 org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration 클래스 로딩 자체를 차단