### PR TITLE
hotfix: Nginx 네트워크 설정 및 HTTPS 프록시 구성

### DIFF
--- a/.github/workflows/deploy-discovery.yml
+++ b/.github/workflows/deploy-discovery.yml
@@ -38,13 +38,13 @@ jobs:
           docker push ${{ secrets.DOCKER_USERNAME }}/discovery-service:latest
 
       # 3. 배포 (Node-1로 전송)
-      - name: Copy Docker Compose to Node-1
+      - name: Copy Docker Compose and Nginx Config to Node-1
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST_1 }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: "deployment/docker-compose-node-1.yml"
+          source: "deployment/docker-compose-node-1.yml,deployment/nginx.conf"
           target: "~/deploy"
           strip_components: 1
 

--- a/deployment/docker-compose-node-1.yml
+++ b/deployment/docker-compose-node-1.yml
@@ -1,5 +1,9 @@
 version: '3.8'
 
+networks:
+  pawbridge-network:
+    driver: bridge
+
 services:
   # 1. Discovery Service (Eureka)
   discovery-service:
@@ -7,6 +11,8 @@ services:
     container_name: discovery-service
     ports:
       - "8761:8761"
+    networks:
+      - pawbridge-network
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_HOSTNAME=${NODE1_PRIVATE_IP}
@@ -29,6 +35,8 @@ services:
     container_name: api-gateway
     ports:
       - "8080:8080"
+    networks:
+      - pawbridge-network
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE1_PRIVATE_IP}
@@ -52,6 +60,8 @@ services:
     container_name: redis
     ports:
       - "6379:6379"
+    networks:
+      - pawbridge-network
     deploy:
       restart_policy:
         condition: on-failure
@@ -63,6 +73,8 @@ services:
     container_name: zipkin
     ports:
       - "9411:9411"
+    networks:
+      - pawbridge-network
     deploy:
       restart_policy:
         condition: on-failure
@@ -74,6 +86,8 @@ services:
     container_name: prometheus
     ports:
       - "9090:9090"
+    networks:
+      - pawbridge-network
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     deploy:
@@ -87,12 +101,13 @@ services:
     container_name: grafana
     ports:
       - "3000:3000"
+    networks:
+      - pawbridge-network
     deploy:
       restart_policy:
         condition: on-failure
         max_attempts: 5
 
-  # 7. Nginx (Optional: In front of Gateway)
   # 7. Nginx (HTTPS Proxy)
   nginx:
     image: nginx:latest
@@ -100,6 +115,8 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    networks:
+      - pawbridge-network
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,0 +1,56 @@
+events { worker_connections 1024; }
+
+http {
+    # Gateway 컨테이너 주소 (Docker 내부망)
+    upstream api-gateway {
+        server api-gateway:8080;
+    }
+
+    # 1. HTTP(80) -> HTTPS(443) 강제 리다이렉트
+    server {
+        listen 80;
+        server_name pawbridge.kr www.pawbridge.kr api.pawbridge.kr;
+        return 301 https://$host$request_uri;
+    }
+
+    # 2. 백엔드 API 설정 (api.pawbridge.kr) -> Gateway로 토스
+    server {
+        listen 443 ssl;
+        server_name api.pawbridge.kr;
+
+        # SSL 인증서 경로 (Certbot이 만들어줄 경로)
+        ssl_certificate /etc/letsencrypt/live/pawbridge.kr/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/pawbridge.kr/privkey.pem;
+
+        # SSL 설정
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            proxy_pass http://api-gateway;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # WebSocket 지원 (필요시)
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+
+    # 3. 프론트엔드 설정 (pawbridge.kr) -> 현재는 임시 페이지
+    server {
+        listen 443 ssl;
+        server_name pawbridge.kr www.pawbridge.kr;
+
+        ssl_certificate /etc/letsencrypt/live/pawbridge.kr/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/pawbridge.kr/privkey.pem;
+
+        location / {
+            return 200 'Welcome to PawBridge! (Frontend Coming Soon)';
+            add_header Content-Type text/plain;
+        }
+    }
+}


### PR DESCRIPTION
## 원인
Docker Compose에 명시적 네트워크 설정이 없어서 Nginx와 API Gateway가 서로 DNS 해석 불가

## 수정 내용

### 1. Docker Compose 네트워크 설정 추가
- `pawbridge-network` 브릿지 네트워크 생성
- 모든 서비스를 같은 네트워크에 연결

### 2. nginx.conf 파일 생성
- HTTPS 프록시 설정
- HTTP → HTTPS 리다이렉트
- api.pawbridge.kr → API Gateway 라우팅

### 3. 워크플로우 업데이트
- deploy-discovery.yml에 nginx.conf 복사 추가

## 테스트 계획
1. PR 머지 후 워크플로우 실행 확인
2. Node 1에서 Nginx 로그에 오류 없는지 확인
