### PR TITLE
hotfix: prometheus.yml 설정 파일 추가

### DIFF
--- a/.github/workflows/deploy-discovery.yml
+++ b/.github/workflows/deploy-discovery.yml
@@ -44,7 +44,7 @@ jobs:
           host: ${{ secrets.EC2_HOST_1 }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: "deployment/docker-compose-node-1.yml,deployment/nginx.conf"
+          source: "deployment/docker-compose-node-1.yml,deployment/nginx.conf,deployment/prometheus.yml"
           target: "~/deploy"
           strip_components: 1
 

--- a/.github/workflows/deploy-discovery.yml
+++ b/.github/workflows/deploy-discovery.yml
@@ -38,15 +38,29 @@ jobs:
           docker push ${{ secrets.DOCKER_USERNAME }}/discovery-service:latest
 
       # 3. 배포 (Node-1로 전송)
-      - name: Copy Docker Compose and Nginx Config to Node-1
+      - name: Copy Docker Compose and Config Files to Node-1
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST_1 }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: "deployment/docker-compose-node-1.yml,deployment/nginx.conf,deployment/prometheus.yml"
+          source: "deployment/docker-compose-node-1.yml,deployment/nginx.conf,infrastructure/prod/prometheus.yml"
           target: "~/deploy"
-          strip_components: 1
+          strip_components: 0
+
+      - name: Organize Config Files on Node-1
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST_1 }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd ~/deploy
+            # 파일 정리 (폴더 구조 flatten)
+            mv deployment/docker-compose-node-1.yml ./ 2>/dev/null || true
+            mv deployment/nginx.conf ./ 2>/dev/null || true
+            mv infrastructure/prod/prometheus.yml ./ 2>/dev/null || true
+            rm -rf deployment infrastructure 2>/dev/null || true
 
       - name: Deploy to Node-1
         uses: appleboy/ssh-action@v1.0.0

--- a/.github/workflows/deploy-elastic-connect.yml
+++ b/.github/workflows/deploy-elastic-connect.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'infrastructure/elasticsearch/**'
       - 'infrastructure/kafka/**'
+      - 'infrastructure/prod/**'
       - '.github/workflows/deploy-elastic-connect.yml'
+      - 'deployment/docker-compose-node-5.yml'
 
 jobs:
   build-and-deploy:
@@ -32,26 +34,16 @@ jobs:
           docker build -t ${{ secrets.DOCKER_USERNAME }}/kafka-connect:latest .
           docker push ${{ secrets.DOCKER_USERNAME }}/kafka-connect:latest
 
-      # SCP: docker-compose-node-5.yml 전송
-      - name: Copy Docker Compose to Node-5
+      # SCP: docker-compose-node-5.yml 및 prod 설정 전송
+      - name: Copy Docker Compose and Prod Config to Node-5
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST_5 }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: "deployment/docker-compose-node-5.yml"
+          source: "deployment/docker-compose-node-5.yml,infrastructure/prod"
           target: "~/deploy"
-          strip_components: 1
-
-      # SCP: infrastructure 폴더 전송 (CDC 설정용)
-      - name: Copy Infrastructure to Node-5
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST_5 }}
-          username: ubuntu
-          key: ${{ secrets.EC2_KEY }}
-          source: "infrastructure"
-          target: "~/deploy"
+          strip_components: 0
 
       # SSH: 배포 실행
       - name: Deploy to Node-5
@@ -62,14 +54,20 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             cd ~/deploy
-            mv docker-compose-node-5.yml docker-compose.yml
+            
+            # 파일 정리
+            mv deployment/docker-compose-node-5.yml docker-compose.yml 2>/dev/null || true
+            mkdir -p connectors
+            cp infrastructure/prod/connectors/*.json connectors/ 2>/dev/null || true
+            rm -rf deployment infrastructure 2>/dev/null || true
 
             # 환경변수 설정
             echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env
-            
-            # Node 3 (Kafka), Node 5 (ES) Private IPs
             echo "NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}" >> .env
             echo "NODE5_PRIVATE_IP=${{ secrets.NODE5_PRIVATE_IP }}" >> .env
+
+            # 커넥터 설정 파일은 템플릿으로만 복사됨
+            # 실제 등록은 수동으로 진행 (플레이스홀더 값 변경 후 curl로 등록)
 
             docker compose pull
             docker compose up -d

--- a/deployment/prometheus.yml
+++ b/deployment/prometheus.yml
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Prometheus 자체 모니터링
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # API Gateway
+  - job_name: 'api-gateway'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['api-gateway:8080']
+
+  # Discovery Service
+  - job_name: 'discovery-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['discovery-service:8761']

--- a/infrastructure/prod/connectors/animal-outbox-connector.json
+++ b/infrastructure/prod/connectors/animal-outbox-connector.json
@@ -1,0 +1,29 @@
+{
+    "name": "animal-outbox-connector",
+    "config": {
+        "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+        "tasks.max": "1",
+        "database.hostname": "<MYSQL_HOST>",
+        "database.port": "3306",
+        "database.user": "<MYSQL_USER>",
+        "database.password": "<MYSQL_PASSWORD>",
+        "database.server.id": "184056",
+        "topic.prefix": "pawbridge-animal",
+        "database.include.list": "pawbridge_animal",
+        "table.include.list": "pawbridge_animal.outbox_events",
+        "database.connectionTimeZone": "Asia/Seoul",
+        "schema.history.internal.kafka.bootstrap.servers": "<KAFKA_BOOTSTRAP_SERVERS>",
+        "schema.history.internal.kafka.topic": "schema-changes.animal.outbox",
+        "snapshot.mode": "when_needed",
+        "transforms": "outbox",
+        "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+        "transforms.outbox.table.field.event.id": "event_id",
+        "transforms.outbox.table.field.event.key": "aggregate_id",
+        "transforms.outbox.table.field.event.timestamp": "created_at",
+        "transforms.outbox.table.field.event.payload": "payload",
+        "transforms.outbox.table.fields.additional.placement": "event_type:header:eventType",
+        "transforms.outbox.route.topic.replacement": "${routedByValue}",
+        "transforms.outbox.route.by.field": "topic",
+        "transforms.outbox.table.expand.json.payload": "true"
+    }
+}

--- a/infrastructure/prod/connectors/community-outbox-connector.json
+++ b/infrastructure/prod/connectors/community-outbox-connector.json
@@ -1,0 +1,29 @@
+{
+    "name": "community-outbox-connector",
+    "config": {
+        "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+        "tasks.max": "1",
+        "database.hostname": "<MYSQL_HOST>",
+        "database.port": "3306",
+        "database.user": "<MYSQL_USER>",
+        "database.password": "<MYSQL_PASSWORD>",
+        "database.server.id": "184057",
+        "topic.prefix": "pawbridge-community",
+        "database.include.list": "pawbridge_community",
+        "table.include.list": "pawbridge_community.outbox_events",
+        "database.connectionTimeZone": "Asia/Seoul",
+        "schema.history.internal.kafka.bootstrap.servers": "<KAFKA_BOOTSTRAP_SERVERS>",
+        "schema.history.internal.kafka.topic": "schema-changes.community.outbox",
+        "snapshot.mode": "when_needed",
+        "transforms": "outbox",
+        "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+        "transforms.outbox.table.field.event.id": "event_id",
+        "transforms.outbox.table.field.event.key": "aggregate_id",
+        "transforms.outbox.table.field.event.timestamp": "created_at",
+        "transforms.outbox.table.field.event.payload": "payload",
+        "transforms.outbox.table.fields.additional.placement": "event_type:header:eventType",
+        "transforms.outbox.route.topic.replacement": "${routedByValue}",
+        "transforms.outbox.route.by.field": "topic",
+        "transforms.outbox.table.expand.json.payload": "true"
+    }
+}

--- a/infrastructure/prod/connectors/elasticsearch-sink-connector.json
+++ b/infrastructure/prod/connectors/elasticsearch-sink-connector.json
@@ -1,0 +1,22 @@
+{
+    "name": "elasticsearch-sink",
+    "config": {
+        "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+        "tasks.max": "1",
+        "topics": "animal.pawbridge_animal.animals",
+        "connection.url": "http://<ELASTICSEARCH_HOST>:9200",
+        "type.name": "_doc",
+        "key.ignore": "true",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter.schemas.enable": "true",
+        "schema.ignore": "false",
+        "write.method": "upsert",
+        "behavior.on.null.values": "delete",
+        "behavior.on.malformed.documents": "fail",
+        "errors.tolerance": "all",
+        "errors.log.enable": "true",
+        "errors.log.include.messages": "true"
+    }
+}

--- a/infrastructure/prod/connectors/payment-outbox-connector.json
+++ b/infrastructure/prod/connectors/payment-outbox-connector.json
@@ -1,0 +1,33 @@
+{
+    "name": "payment-outbox-connector",
+    "config": {
+        "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+        "tasks.max": "1",
+        "database.hostname": "<MYSQL_HOST>",
+        "database.port": "3306",
+        "database.user": "<MYSQL_USER>",
+        "database.password": "<MYSQL_PASSWORD>",
+        "database.connectionTimeZone": "Asia/Seoul",
+        "database.server.id": "2005",
+        "topic.prefix": "payment",
+        "snapshot.mode": "initial",
+        "database.include.list": "pawbridge_payment",
+        "table.include.list": "pawbridge_payment.outbox",
+        "schema.history.internal.kafka.bootstrap.servers": "<KAFKA_BOOTSTRAP_SERVERS>",
+        "schema.history.internal.kafka.topic": "schema-changes.payment",
+        "transforms": "outbox",
+        "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+        "transforms.outbox.table.field.event.id": "id",
+        "transforms.outbox.table.field.event.key": "aggregate_id",
+        "transforms.outbox.table.field.event.timestamp": "created_at",
+        "transforms.outbox.table.field.event.payload": "payload",
+        "transforms.outbox.table.fields.additional.placement": "event_type:header:eventType",
+        "transforms.outbox.route.topic.replacement": "payment.events",
+        "transforms.outbox.route.by.field": "aggregate_type",
+        "transforms.outbox.table.expand.json.payload": "true",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter.schemas.enable": "false"
+    }
+}

--- a/infrastructure/prod/connectors/store-es-sink-connector.json
+++ b/infrastructure/prod/connectors/store-es-sink-connector.json
@@ -1,0 +1,21 @@
+{
+    "name": "store-es-sink-connector",
+    "config": {
+        "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+        "tasks.max": "1",
+        "topics": "store.outbox.events",
+        "connection.url": "http://<ELASTICSEARCH_HOST>:9200",
+        "type.name": "_doc",
+        "key.ignore": "true",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter.schemas.enable": "false",
+        "schema.ignore": "true",
+        "write.method": "upsert",
+        "behavior.on.null.values": "delete",
+        "errors.tolerance": "all",
+        "errors.log.enable": "true",
+        "errors.log.include.messages": "true"
+    }
+}

--- a/infrastructure/prod/connectors/store-outbox-connector.json
+++ b/infrastructure/prod/connectors/store-outbox-connector.json
@@ -1,0 +1,33 @@
+{
+    "name": "store-outbox-connector",
+    "config": {
+        "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+        "tasks.max": "1",
+        "database.hostname": "<MYSQL_HOST>",
+        "database.port": "3306",
+        "database.user": "<MYSQL_USER>",
+        "database.password": "<MYSQL_PASSWORD>",
+        "database.connectionTimeZone": "Asia/Seoul",
+        "database.server.id": "2004",
+        "topic.prefix": "store-v3",
+        "snapshot.mode": "initial",
+        "database.include.list": "pawbridge_store",
+        "table.include.list": "pawbridge_store.outbox",
+        "schema.history.internal.kafka.bootstrap.servers": "<KAFKA_BOOTSTRAP_SERVERS>",
+        "schema.history.internal.kafka.topic": "schema-changes.store-v2",
+        "transforms": "outbox",
+        "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+        "transforms.outbox.table.field.event.id": "id",
+        "transforms.outbox.table.field.event.key": "aggregate_id",
+        "transforms.outbox.table.field.event.timestamp": "created_at",
+        "transforms.outbox.table.field.event.payload": "payload",
+        "transforms.outbox.table.fields.additional.placement": "event_type:header:eventType",
+        "transforms.outbox.route.topic.replacement": "store.outbox.events",
+        "transforms.outbox.route.by.field": "aggregate_type",
+        "transforms.outbox.table.expand.json.payload": "true",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter.schemas.enable": "false"
+    }
+}

--- a/infrastructure/prod/connectors/user-outbox-connector.json
+++ b/infrastructure/prod/connectors/user-outbox-connector.json
@@ -1,0 +1,33 @@
+{
+    "name": "user-outbox-connector",
+    "config": {
+        "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+        "tasks.max": "1",
+        "database.hostname": "<MYSQL_HOST>",
+        "database.port": "3306",
+        "database.user": "<MYSQL_USER>",
+        "database.password": "<MYSQL_PASSWORD>",
+        "database.connectionTimeZone": "Asia/Seoul",
+        "database.server.id": "2006",
+        "topic.prefix": "user",
+        "snapshot.mode": "initial",
+        "database.include.list": "pawbridge_user",
+        "table.include.list": "pawbridge_user.outbox",
+        "schema.history.internal.kafka.bootstrap.servers": "<KAFKA_BOOTSTRAP_SERVERS>",
+        "schema.history.internal.kafka.topic": "schema-changes.user.outbox",
+        "transforms": "outbox",
+        "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+        "transforms.outbox.table.field.event.id": "id",
+        "transforms.outbox.table.field.event.key": "aggregate_id",
+        "transforms.outbox.table.field.event.timestamp": "created_at",
+        "transforms.outbox.table.field.event.payload": "payload",
+        "transforms.outbox.table.fields.additional.placement": "event_type:header:eventType",
+        "transforms.outbox.route.topic.replacement": "user.favorite.events",
+        "transforms.outbox.route.by.field": "aggregate_type",
+        "transforms.outbox.table.expand.json.payload": "true",
+        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "key.converter.schemas.enable": "false",
+        "value.converter.schemas.enable": "false"
+    }
+}

--- a/infrastructure/prod/prometheus.yml
+++ b/infrastructure/prod/prometheus.yml
@@ -3,18 +3,19 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  # Prometheus 자체 모니터링
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
 
-  # API Gateway
+  - job_name: 'zipkin'
+    static_configs:
+      - targets: ['zipkin:9411']
+
   - job_name: 'api-gateway'
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['api-gateway:8080']
 
-  # Discovery Service
   - job_name: 'discovery-service'
     metrics_path: '/actuator/prometheus'
     static_configs:


### PR DESCRIPTION
# Hotfix: Prometheus 설정 파일 추가, Infrastructure 로컬/배포 설정 분리

## 문제 설명
1. Prometheus 컨테이너가 `Created` 상태로 시작되지 않음
2. 로컬 개발용 설정과 배포용 설정이 분리되어 있지 않음

## 원인
- prometheus.yml 파일이 없어서 Docker가 디렉토리로 자동 생성
- 볼륨 마운트 실패로 컨테이너 시작 불가

## 수정 내용
### 1. deployment/prometheus.yml (신규)
- Prometheus 기본 설정
- API Gateway 메트릭 수집 설정

### 2. deploy-discovery.yml 수정
- 배포 시 prometheus.yml 파일 복사 추가

### 3. infrastructure/prod 폴더 생성
배포용 설정 파일 템플릿을 별도 폴더로 분리

### 4. Kafka Connect 커넥터
- 수동 등록용 템플릿으로 변경
- 민감 정보는 플레이스홀더로 처리 (`<MYSQL_HOST>`, `<MYSQL_PASSWORD>` 등)

## 변경된 파일
- deployment/prometheus.yml (신규)
- .github/workflows/deploy-discovery.yml

## 📁 변경된 파일
### 신규
- infrastructure/prod/prometheus.yml
- infrastructure/prod/connectors/*.json (7개 파일)
- infrastructure/prod/README.md

### 수정
- .github/workflows/deploy-discovery.yml
- .github/workflows/deploy-elastic-connect.yml

### 삭제
- deployment/prometheus.yml