### PR TITLE
fix: Spring Security에서 CORS 활성화하여 프론트엔드 요청 허용

### DIFF
--- a/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
@@ -20,6 +20,9 @@ public class SecurityConfig {
         http
                 // CSRF 비활성화 (JWT 사용하므로 불필요)
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                
+                // CORS 활성화 (Spring Cloud Gateway CORS 설정 사용)
+                .cors(cors -> {})
 
                 // 모든 요청 허용 (JWT Filter에서 검증)
                 .authorizeExchange(exchange -> exchange
@@ -28,4 +31,5 @@ public class SecurityConfig {
 
         return http.build();
     }
+
 }


### PR DESCRIPTION
## 📋 변경 사항
### 문제
- 프론트엔드(www.pawbridge.kr)에서 API 요청 시 403 Forbidden 발생
- Postman에서는 정상 작동, 브라우저에서만 실패

### 원인
- Spring Security가 CORS Preflight(OPTIONS) 요청을 차단
- spring.cloud.gateway.globalcors yml 설정은 되어 있었으나, Spring Security에서 CORS가 비활성화 상태

### 해결
- SecurityConfig.java에 .cors(cors -> {}) 추가
- Spring Security가 yml의 CORS 설정을 사용하도록 활성화

## 📁 변경 파일
- api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java

## ✅ 테스트
- [ ] 프론트엔드에서 API 요청 시 200 OK 확인
- [ ] OPTIONS Preflight 요청에 Access-Control-Allow-Origin 헤더 포함 확인