### PR TITLE
fix: WebFlux 환경에서 CORS 명시적 설정 추가

### DIFF
--- a/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
@@ -5,10 +5,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * API Gateway Security 설정
  * - CSRF 비활성화 (JWT 사용)
+ * - CORS 설정 (프론트엔드 요청 허용)
  * - 모든 요청 허용 (JWT Filter에서 인증 처리)
  */
 @Configuration
@@ -21,8 +28,8 @@ public class SecurityConfig {
                 // CSRF 비활성화 (JWT 사용하므로 불필요)
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 
-                // CORS 활성화 (Spring Cloud Gateway CORS 설정 사용)
-                .cors(cors -> {})
+                // CORS 활성화 (corsConfigurationSource Bean 사용)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
                 // 모든 요청 허용 (JWT Filter에서 검증)
                 .authorizeExchange(exchange -> exchange
@@ -32,4 +39,37 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        
+        // 허용할 Origin 패턴
+        configuration.setAllowedOriginPatterns(Arrays.asList(
+                "https://pawbridge.kr",
+                "https://www.pawbridge.kr",
+                "https://*.pawbridge.kr",
+                "http://localhost:3000",
+                "http://localhost:5173"
+        ));
+        
+        // 허용할 HTTP 메서드
+        configuration.setAllowedMethods(Arrays.asList(
+                "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
+        ));
+        
+        // 허용할 헤더
+        configuration.setAllowedHeaders(Arrays.asList(
+                "Authorization", "Content-Type", "Accept"
+        ));
+        
+        // 노출할 헤더
+        configuration.setExposedHeaders(List.of("Authorization"));
+        
+        // 자격 증명 허용 여부
+        configuration.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }


### PR DESCRIPTION
## 📋 변경 사항

### 문제
- 프론트엔드(`www.pawbridge.kr`)에서 API 요청 시 403 Forbidden 발생
- Postman에서는 정상 동작, 브라우저에서만 실패
- Spring Security가 CORS Preflight(OPTIONS) 요청을 차단

### 원인
- WebFlux 환경에서 `spring.cloud.gateway.globalcors` yml 설정 Bean이 Spring Security에 자동 주입되지 않음

### 해결
- SecurityConfig.java에 `CorsConfigurationSource` Bean 명시적 등록
- `.cors(cors -> cors.configurationSource(corsConfigurationSource()))` 설정

## 📁 변경 파일
- api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java

## ✅ 테스트
- [ ] OPTIONS Preflight 요청에 `Access-Control-Allow-Origin` 헤더 포함 확인
- [ ] 프론트엔드에서 API 요청 시 200 OK 확인