### PR TITLE
fix: Docker 컨테이너 타임존 설정 추가 (TZ=Asia/Seoul)

### DIFF
--- a/deployment/docker-compose-node-1.yml
+++ b/deployment/docker-compose-node-1.yml
@@ -14,6 +14,7 @@ services:
     networks:
       - pawbridge-network
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_HOSTNAME=${NODE1_PRIVATE_IP}
       - CONFIG_SERVER_HOST=${CONFIG_SERVER_HOST} # Node-2 IP:8888
@@ -38,6 +39,7 @@ services:
     networks:
       - pawbridge-network
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE1_PRIVATE_IP}
       - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true

--- a/deployment/docker-compose-node-2.yml
+++ b/deployment/docker-compose-node-2.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - CONFIG_ENCRYPT_KEY=${CONFIG_ENCRYPT_KEY}
       - CONFIG_REPO_URI=${CONFIG_REPO_URI}
@@ -32,6 +33,7 @@ services:
     ports:
       - "3306:3306"
     environment:
+      - TZ=Asia/Seoul
       - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
       - MYSQL_DATABASE=pawbridge
     volumes:
@@ -48,6 +50,7 @@ services:
     ports:
       - "5601:5601"
     environment:
+      - TZ=Asia/Seoul
       - ELASTICSEARCH_HOSTS=http://${NODE5_PRIVATE_IP}:9200
     deploy:
       restart_policy:

--- a/deployment/docker-compose-node-3.yml
+++ b/deployment/docker-compose-node-3.yml
@@ -41,6 +41,7 @@ services:
     ports:
       - "9020:9020"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE3_PRIVATE_IP}
       - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true

--- a/deployment/docker-compose-node-4.yml
+++ b/deployment/docker-compose-node-4.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "8081:8081"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE4_PRIVATE_IP}
       - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true
@@ -34,6 +35,7 @@ services:
     ports:
       - "8089:8089"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE4_PRIVATE_IP}
       - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true
@@ -64,6 +66,7 @@ services:
     ports:
       - "8085:8085"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE4_PRIVATE_IP}
       - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true
@@ -94,6 +97,7 @@ services:
     ports:
       - "8084:8084"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=dev
       - EUREKA_INSTANCE_IP_ADDRESS=${NODE4_PRIVATE_IP}
       - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true

--- a/deployment/docker-compose-node-5.yml
+++ b/deployment/docker-compose-node-5.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "9200:9200"
     environment:
+      - TZ=Asia/Seoul
       - discovery.type=single-node
       - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx1000m"
@@ -25,6 +26,7 @@ services:
     ports:
       - "8083:8083"
     environment:
+      TZ: Asia/Seoul
       CONNECT_BOOTSTRAP_SERVERS: "${NODE3_PRIVATE_IP}:9092"
       CONNECT_REST_ADVERTISED_HOST_NAME: "kafka-connect"
       CONNECT_GROUP_ID: "compose-connect-group"


### PR DESCRIPTION
## 변경 사항
Docker 컨테이너에 타임존 환경변수(TZ)가 설정되어 있지 않아 UTC 기준으로 동작하는 문제 수정
- 문제: Animal Service 배치 스케줄러가 새벽 2시(KST)에 실행되지 않음
- 원인: Docker 컨테이너 기본 타임존이 UTC → cron이 02:00 UTC(= 11:00 KST)에 실행됨
- 해결: 모든 서비스 컨테이너에 `TZ=Asia/Seoul` 환경변수 추가

### 수정 파일
- deployment/docker-compose-node-1.yml - Discovery, API Gateway
- deployment/docker-compose-node-2.yml - Config Server, MySQL, Kibana
- deployment/docker-compose-node-3.yml - Animal Service
- deployment/docker-compose-node-4.yml - User, Community, Store, Payment
- deployment/docker-compose-node-5.yml - Elasticsearch, Kafka Connect

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #79 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)
