### PR TITLE
fix: Kafka 볼륨 추가로 커넥터 데이터 영속성 확보

### DIFF
--- a/deployment/docker-compose-node-3.yml
+++ b/deployment/docker-compose-node-3.yml
@@ -27,6 +27,8 @@ services:
       # Listeners: Internal for Docker network, External for other nodes
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${NODE3_PRIVATE_IP}:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    volumes:
+      - kafka_data:/var/lib/kafka/data
     depends_on:
       - zookeeper
     deploy:
@@ -63,3 +65,6 @@ services:
       restart_policy:
         condition: on-failure
         max_attempts: 5
+
+volumes:
+  kafka_data:


### PR DESCRIPTION
## 변경 사항
Node-3 docker-compose에 Kafka 데이터 볼륨을 추가하여 컨테이너 재시작 시에도 
Kafka 토픽 데이터(커넥터 설정 포함)가 유지되도록 수정했습니다.

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #81 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 볼륨 추가 후 최초 1회는 커넥터 수동 재등록 필요
- 이후부터는 Kafka 재시작해도 커넥터 설정 유지됨