### PR TITLE
feat: 배치 Job 완료 후 Elasticsearch 자동 인덱싱 추가

### DIFF
--- a/animal-service/src/main/java/com/pawbridge/animalservice/batch/job/ApmsAnimalBatchJob.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/batch/job/ApmsAnimalBatchJob.java
@@ -5,6 +5,7 @@ import com.pawbridge.animalservice.batch.reader.ApmsItemReader;
 import com.pawbridge.animalservice.batch.writer.AnimalItemWriter;
 import com.pawbridge.animalservice.dto.apms.ApmsAnimal;
 import com.pawbridge.animalservice.entity.Animal;
+import com.pawbridge.animalservice.service.ElasticsearchIndexService;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,7 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataAccessException;
@@ -21,6 +23,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 /**
  * APMS API 동기화 Batch Job 설정
  * - APMS API로부터 유기동물 데이터를 조회하여 DB에 저장
+ * - 저장 완료 후 Elasticsearch에 자동 인덱싱
  */
 @Slf4j
 @Configuration
@@ -33,16 +36,20 @@ public class ApmsAnimalBatchJob {
     private final ApmsItemReader apmsItemReader;
     private final AnimalItemProcessor animalItemProcessor;
     private final AnimalItemWriter animalItemWriter;
+    private final ElasticsearchIndexService elasticsearchIndexService;
 
     private static final int CHUNK_SIZE = 500; // Reader의 PAGE_SIZE와 동일하게 설정 (메모리 효율)
 
     /**
      * APMS 동물 동기화 Job
+     * - Step 1: APMS API → MySQL 저장
+     * - Step 2: MySQL → Elasticsearch 인덱싱
      */
     @Bean
     public Job apmsAnimalSyncJob() {
         return new JobBuilder("apmsAnimalSyncJob", jobRepository)
                 .start(apmsAnimalSyncStep())
+                .next(elasticsearchIndexStep())
                 .build();
     }
 
@@ -68,4 +75,22 @@ public class ApmsAnimalBatchJob {
                 .skip(Exception.class) // 일반 예외도 스킵 (NPE 등)
                 .build();
     }
+
+    /**
+     * Elasticsearch 인덱싱 Step
+     * - MySQL에 저장된 전체 동물 데이터를 Elasticsearch에 인덱싱
+     * - 기존 ES 데이터 삭제 후 전체 재인덱싱 (데이터 일관성 보장)
+     */
+    @Bean
+    public Step elasticsearchIndexStep() {
+        return new StepBuilder("elasticsearchIndexStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    log.info("[BATCH] Elasticsearch 인덱싱 Step 시작");
+                    long indexedCount = elasticsearchIndexService.reindexAllAnimals();
+                    log.info("[BATCH] Elasticsearch 인덱싱 Step 완료: {} 건", indexedCount);
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
 }
+


### PR DESCRIPTION
## 변경 사항
APMS 동물 데이터 동기화 배치 완료 후 Elasticsearch에 자동으로 인덱싱되도록
`elasticsearchIndexStep` Step을 추가했습니다.

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #83 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 배치 Step 흐름: `apmsAnimalSyncStep` → `elasticsearchIndexStep`
- 새벽 2시 스케줄 배치 및 수동 배치 모두 적용됨