### PR TITLE
fix: API Gateway CORS 설정 충돌 해결

### DIFF
--- a/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
@@ -5,17 +5,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.reactive.CorsConfigurationSource;
-import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * API Gateway Security 설정
  * - CSRF 비활성화 (JWT 사용)
- * - CORS 설정 (프론트엔드 요청 허용)
+ * - CORS 설정은 application.yml의 globalcors 사용
  * - 모든 요청 허용 (JWT Filter에서 인증 처리)
  */
 @Configuration
@@ -28,8 +22,9 @@ public class SecurityConfig {
                 // CSRF 비활성화 (JWT 사용하므로 불필요)
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 
-                // CORS 활성화 (corsConfigurationSource Bean 사용)
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // CORS는 application.yml의 spring.cloud.gateway.globalcors 설정 사용
+                // Security 레벨에서는 비활성화
+                .cors(ServerHttpSecurity.CorsSpec::disable)
 
                 // 모든 요청 허용 (JWT Filter에서 검증)
                 .authorizeExchange(exchange -> exchange
@@ -38,38 +33,5 @@ public class SecurityConfig {
 
         return http.build();
     }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        
-        // 허용할 Origin 패턴
-        configuration.setAllowedOriginPatterns(Arrays.asList(
-                "https://pawbridge.kr",
-                "https://www.pawbridge.kr",
-                "https://*.pawbridge.kr",
-                "http://localhost:3000",
-                "http://localhost:5173"
-        ));
-        
-        // 허용할 HTTP 메서드
-        configuration.setAllowedMethods(Arrays.asList(
-                "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
-        ));
-        
-        // 허용할 헤더
-        configuration.setAllowedHeaders(Arrays.asList(
-                "Authorization", "Content-Type", "Accept"
-        ));
-        
-        // 노출할 헤더
-        configuration.setExposedHeaders(List.of("Authorization"));
-        
-        // 자격 증명 허용 여부
-        configuration.setAllowCredentials(false);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
 }
+


### PR DESCRIPTION
## 변경 사항
SecurityConfig.java에서 자체 CORS 설정을 제거하고 
application.yml의 globalcors 설정만 사용하도록 통합했습니다.

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #87 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 이전: SecurityConfig + yml 설정 충돌로 CORS preflight 실패
- 이후: yml globalcors 설정 단일화로 정상 동작