### PR TITLE
fix: OPTIONS preflight 403 Forbidden 해결

### DIFF
--- a/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.pawbridge.apigateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
@@ -10,6 +11,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
  * API Gateway Security 설정
  * - CSRF 비활성화 (JWT 사용)
  * - CORS 설정은 application.yml의 globalcors 사용
+ * - OPTIONS 요청 명시적 허용 (CORS preflight)
  * - 모든 요청 허용 (JWT Filter에서 인증 처리)
  */
 @Configuration
@@ -26,12 +28,16 @@ public class SecurityConfig {
                 // Security 레벨에서는 비활성화
                 .cors(ServerHttpSecurity.CorsSpec::disable)
 
-                // 모든 요청 허용 (JWT Filter에서 검증)
+                // 요청 허용 설정
                 .authorizeExchange(exchange -> exchange
+                        // OPTIONS 요청 명시적 허용 (CORS preflight)
+                        .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        // 나머지 모든 요청 허용 (JWT Filter에서 검증)
                         .anyExchange().permitAll()
                 );
 
         return http.build();
     }
 }
+
 


### PR DESCRIPTION
## 변경 사항
1. SecurityConfig에서 자체 CORS 설정을 제거하고 yml globalcors 설정만 사용하도록 통합
2. OPTIONS preflight 요청을 Spring Security에서 명시적으로 허용

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #87 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
- 이전: SecurityConfig과 yml CORS 설정 충돌 + OPTIONS 403 Forbidden
- 이후: yml globalcors 단일화 + OPTIONS 명시적 permitAll