### PR TITLE
refactor: ProductServiceImpl 리팩토링 및 상품 삭제 API

### DIFF
--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/ProductController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/ProductController.java
@@ -68,4 +68,10 @@ public class ProductController {
         ProductSearchResponse response = productSearchService.searchProducts(searchRequest);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
+        productService.deleteProduct(productId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductCacheService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductCacheService.java
@@ -1,0 +1,51 @@
+package com.pawbridge.storeservice.domain.product.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Product Cache Service
+ * - 상품 상세 페이지 캐시 관리
+ * - Redis 기반 캐시 무효화
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductCacheService {
+
+    private final StringRedisTemplate redisTemplate;
+    
+    private static final String CACHE_KEY_PREFIX = "productDetails::";
+
+    /**
+     * 상품 상세 캐시 무효화
+     * - 재고 변경, 상품 수정/삭제 시 호출
+     * @param productId 상품 ID
+     */
+    public void evictProductCache(Long productId) {
+        try {
+            String cacheKey = CACHE_KEY_PREFIX + productId;
+            Boolean deleted = redisTemplate.delete(cacheKey);
+            if (Boolean.TRUE.equals(deleted)) {
+                log.info(">>> [CACHE EVICT] ProductId: {} 캐시 삭제 완료", productId);
+            } else {
+                log.debug(">>> [CACHE EVICT] ProductId: {} 캐시 없음 (이미 만료됨)", productId);
+            }
+        } catch (Exception e) {
+            log.error("캐시 무효화 실패: productId={}", productId, e);
+            // 캐시 실패는 치명적이지 않으므로 예외 전파하지 않음
+        }
+    }
+
+    /**
+     * 여러 상품 캐시 일괄 무효화
+     * @param productIds 상품 ID 목록
+     */
+    public void evictProductCaches(Iterable<Long> productIds) {
+        for (Long productId : productIds) {
+            evictProductCache(productId);
+        }
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductOutboxService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductOutboxService.java
@@ -1,0 +1,107 @@
+package com.pawbridge.storeservice.domain.product.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawbridge.storeservice.common.entity.Outbox;
+import com.pawbridge.storeservice.common.repository.OutboxRepository;
+import com.pawbridge.storeservice.domain.product.dto.ProductEventPayload;
+import com.pawbridge.storeservice.domain.product.entity.Product;
+import com.pawbridge.storeservice.domain.product.entity.ProductSKU;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+/**
+ * Product Outbox Service
+ * - SKU 이벤트를 Outbox 테이블에 저장
+ * - Debezium CDC로 Kafka → Elasticsearch 연동
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductOutboxService {
+
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * SKU 생성/수정 이벤트 발행
+     * @param product 상품 엔티티
+     * @param sku SKU 엔티티
+     * @param isPrimary 대표 SKU 여부
+     */
+    public void publishSkuEvent(Product product, ProductSKU sku, boolean isPrimary) {
+        ProductEventPayload eventPayload = buildEventPayload(product, sku, isPrimary);
+        saveOutboxEvent(sku.getId(), "SKU_UPDATED", eventPayload);
+    }
+
+    /**
+     * SKU 삭제 이벤트 발행
+     * @param skuId 삭제된 SKU ID
+     */
+    public void publishSkuDeleteEvent(Long skuId) {
+        try {
+            // 삭제 이벤트는 ID만 포함
+            String payload = objectMapper.writeValueAsString(
+                java.util.Map.of("skuId", skuId, "deleted", true)
+            );
+            
+            Outbox outbox = Outbox.builder()
+                    .aggregateType("PRODUCT_SKU")
+                    .aggregateId(String.valueOf(skuId))
+                    .eventType("SKU_DELETED")
+                    .payload(payload)
+                    .build();
+            outboxRepository.save(outbox);
+            
+            log.info(">>> [OUTBOX] SKU 삭제 이벤트 발행: skuId={}", skuId);
+        } catch (JsonProcessingException e) {
+            log.error("SKU 삭제 이벤트 페이로드 직렬화 실패: skuId={}", skuId, e);
+            throw new RuntimeException("Outbox 이벤트 생성 실패", e);
+        }
+    }
+
+    /**
+     * 이벤트 페이로드 빌드
+     */
+    private ProductEventPayload buildEventPayload(Product product, ProductSKU sku, boolean isPrimary) {
+        return ProductEventPayload.builder()
+                .skuId(sku.getId())
+                .productId(product.getId())
+                .categoryId(product.getCategory() != null ? product.getCategory().getId() : null)
+                .productName(product.getName())
+                .skuCode(sku.getSkuCode())
+                .optionName(sku.generateOptionName())
+                .price(sku.getPrice())
+                .stockQuantity(sku.getStockQuantity())
+                .isPrimarySku(isPrimary)
+                .status(product.getStatus().name())
+                .imageUrl(product.getImageUrl())
+                .createdAt(product.getCreatedAt())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    /**
+     * Outbox 테이블에 이벤트 저장
+     */
+    private void saveOutboxEvent(Long skuId, String eventType, ProductEventPayload payload) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(payload);
+            Outbox outbox = Outbox.builder()
+                    .aggregateType("PRODUCT_SKU")
+                    .aggregateId(String.valueOf(skuId))
+                    .eventType(eventType)
+                    .payload(payloadJson)
+                    .build();
+            outboxRepository.save(outbox);
+            
+            log.debug(">>> [OUTBOX] 이벤트 발행: {}, skuId={}", eventType, skuId);
+        } catch (JsonProcessingException e) {
+            log.error("SKU 이벤트 페이로드 직렬화 실패: skuId={}", skuId, e);
+            throw new RuntimeException("Outbox 이벤트 생성 실패", e);
+        }
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductService.java
@@ -11,4 +11,5 @@ public interface ProductService {
     ProductResponse updateProduct(Long productId, com.pawbridge.storeservice.domain.product.dto.ProductUpdateRequest request);
     void decreaseStock(Long skuId, int quantity);
     void increaseStock(Long skuId, int quantity);
+    void deleteProduct(Long productId);
 }


### PR DESCRIPTION
## 변경 사항
ProductServiceImpl의 과도한 의존성을 분리하고 상품 삭제 API를 추가했습니다.

### 주요 변경
- **ProductOutboxService** (NEW): Outbox 이벤트 발행 로직 분리
- **ProductCacheService** (NEW): 캐시 무효화 로직 분리
- **ProductServiceImpl**: 의존성 9개 → 8개, 335줄 → 246줄
- **DELETE /api/products/{productId}**: 상품 삭제 엔드포인트 추가

### 버그 수정
- 상품 삭제 시 SKUValue FK 제약 조건 위반 오류 해결 (명시적 삭제 순서 적용)

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #92 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트 완료 (등록 → 조회 → 삭제 → 삭제 확인)
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (store-service-api.md)