### PR TITLE
feat: 카테고리 삭제 API 및 ProductServiceImpl 리팩토링

### DIFF
--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/cart/repository/CartItemRepository.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/cart/repository/CartItemRepository.java
@@ -4,6 +4,13 @@ import com.pawbridge.storeservice.domain.cart.entity.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    
+    /**
+     * 해당 SKU ID 목록 중 하나라도 장바구니에 있는지 확인
+     */
+    boolean existsByProductSkuIdIn(List<Long> skuIds);
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/CategoryController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/CategoryController.java
@@ -28,4 +28,10 @@ public class CategoryController {
         List<CategoryResponse> responses = categoryService.getAllCategories();
         return ResponseEntity.ok(responses);
     }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long categoryId) {
+        categoryService.deleteCategory(categoryId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/CategoryService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/CategoryService.java
@@ -48,4 +48,17 @@ public class CategoryService {
                 .map(CategoryResponse::from)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found: " + categoryId));
+        
+        // 하위 카테고리가 있는지 확인
+        if (!category.getChildren().isEmpty()) {
+            throw new IllegalStateException("하위 카테고리가 있어 삭제할 수 없습니다.");
+        }
+        
+        categoryRepository.delete(category);
+    }
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductOptionService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductOptionService.java
@@ -1,0 +1,64 @@
+package com.pawbridge.storeservice.domain.product.service;
+
+import com.pawbridge.storeservice.domain.product.dto.OptionGroupCreateDto;
+import com.pawbridge.storeservice.domain.product.entity.OptionGroup;
+import com.pawbridge.storeservice.domain.product.entity.OptionValue;
+import com.pawbridge.storeservice.domain.product.entity.Product;
+import com.pawbridge.storeservice.domain.product.repository.OptionGroupRepository;
+import com.pawbridge.storeservice.domain.product.repository.OptionValueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Product Option Service
+ * - 옵션 그룹 및 옵션 값 관리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductOptionService {
+
+    private final OptionGroupRepository optionGroupRepository;
+    private final OptionValueRepository optionValueRepository;
+
+    /**
+     * 옵션 그룹 및 옵션 값 생성
+     * @param product 상품 엔티티
+     * @param optionGroups 옵션 그룹 DTO 목록
+     * @return "그룹명:값명" -> OptionValue 맵 (SKU 연결용)
+     */
+    public Map<String, OptionValue> createOptions(Product product, List<OptionGroupCreateDto> optionGroups) {
+        Map<String, OptionValue> optionValueMap = new HashMap<>();
+        
+        if (optionGroups == null || optionGroups.isEmpty()) {
+            return optionValueMap;
+        }
+        
+        for (OptionGroupCreateDto groupDto : optionGroups) {
+            OptionGroup group = OptionGroup.builder()
+                    .product(product)
+                    .name(groupDto.getName())
+                    .build();
+            optionGroupRepository.save(group);
+
+            for (String valName : groupDto.getValues()) {
+                OptionValue value = OptionValue.builder()
+                        .optionGroup(group)
+                        .name(valName)
+                        .build();
+                optionValueRepository.save(value);
+                optionValueMap.put(groupDto.getName() + ":" + valName, value);
+            }
+        }
+        
+        log.debug(">>> [OPTION] 옵션 생성 완료: productId={}, 옵션 수={}", 
+                product.getId(), optionValueMap.size());
+        
+        return optionValueMap;
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductSKUService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductSKUService.java
@@ -1,0 +1,107 @@
+package com.pawbridge.storeservice.domain.product.service;
+
+import com.pawbridge.storeservice.domain.product.dto.SkuCreateDto;
+import com.pawbridge.storeservice.domain.product.entity.OptionValue;
+import com.pawbridge.storeservice.domain.product.entity.Product;
+import com.pawbridge.storeservice.domain.product.entity.ProductSKU;
+import com.pawbridge.storeservice.domain.product.entity.SKUValue;
+import com.pawbridge.storeservice.domain.product.repository.ProductSKURepository;
+import com.pawbridge.storeservice.domain.product.repository.SKUValueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Product SKU Service
+ * - SKU 및 SKU-옵션값 연결 관리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductSKUService {
+
+    private final ProductSKURepository productSKURepository;
+    private final SKUValueRepository skuValueRepository;
+
+    /**
+     * SKU 생성 및 옵션 값과 연결
+     * @param product 상품 엔티티
+     * @param skuDtos SKU 생성 DTO 목록
+     * @param optionValueMap "그룹명:값명" -> OptionValue 맵
+     * @return 생성된 SKU 목록
+     */
+    public List<ProductSKU> createSkus(Product product, List<SkuCreateDto> skuDtos, 
+                                        Map<String, OptionValue> optionValueMap) {
+        List<ProductSKU> savedSkus = new ArrayList<>();
+        
+        if (skuDtos == null || skuDtos.isEmpty()) {
+            return savedSkus;
+        }
+        
+        for (SkuCreateDto skuDto : skuDtos) {
+            // SKU 저장
+            ProductSKU sku = ProductSKU.builder()
+                    .product(product)
+                    .skuCode(skuDto.getSkuCode())
+                    .price(skuDto.getPrice())
+                    .stockQuantity(skuDto.getStockQuantity())
+                    .build();
+            productSKURepository.save(sku);
+            
+            savedSkus.add(sku);
+            product.getSkus().add(sku);
+
+            // 옵션 연결 (SKUValue)
+            if (skuDto.getOptions() != null) {
+                for (Map.Entry<String, String> entry : skuDto.getOptions().entrySet()) {
+                    String key = entry.getKey() + ":" + entry.getValue();
+                    OptionValue optionValue = optionValueMap.get(key);
+                    if (optionValue == null) {
+                        throw new IllegalArgumentException("SKU 내 유효하지 않은 옵션 값입니다: " + key);
+                    }
+                    SKUValue skuValue = SKUValue.builder()
+                            .productSKU(sku)
+                            .optionValue(optionValue)
+                            .build();
+                    skuValueRepository.save(skuValue);
+                    sku.getSkuValues().add(skuValue);
+                }
+            }
+        }
+        
+        log.debug(">>> [SKU] SKU 생성 완료: productId={}, SKU 수={}", 
+                product.getId(), savedSkus.size());
+        
+        return savedSkus;
+    }
+
+    /**
+     * 대표 SKU 찾기 (최저가 → 동일 시 낮은 ID)
+     */
+    public ProductSKU findPrimarySku(List<ProductSKU> skus) {
+        if (skus == null || skus.isEmpty()) {
+            return null;
+        }
+        
+        return skus.stream()
+                .min((s1, s2) -> {
+                    int priceCompare = s1.getPrice().compareTo(s2.getPrice());
+                    if (priceCompare != 0) return priceCompare;
+                    if (s1.getId() == null || s2.getId() == null) return 0;
+                    return s1.getId().compareTo(s2.getId());
+                })
+                .orElse(skus.get(0));
+    }
+
+    /**
+     * SKU의 SKUValue 삭제 (상품 삭제 전 호출)
+     */
+    public void deleteSkuValues(ProductSKU sku) {
+        skuValueRepository.deleteAll(sku.getSkuValues());
+        sku.getSkuValues().clear();
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductServiceImpl.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/service/ProductServiceImpl.java
@@ -1,21 +1,19 @@
 package com.pawbridge.storeservice.domain.product.service;
 
-import com.pawbridge.storeservice.domain.product.dto.OptionGroupCreateDto;
-import com.pawbridge.storeservice.domain.product.dto.SkuCreateDto;
+import com.pawbridge.storeservice.domain.cart.repository.CartItemRepository;
 import com.pawbridge.storeservice.domain.product.dto.SkuUpdateDto;
 import com.pawbridge.storeservice.domain.product.dto.ProductCreateRequest;
-import com.pawbridge.storeservice.domain.product.dto.ProductUpdateRequest;
 import com.pawbridge.storeservice.domain.product.dto.ProductResponse;
 import com.pawbridge.storeservice.domain.product.entity.*;
-import com.pawbridge.storeservice.domain.product.repository.*;
+import com.pawbridge.storeservice.domain.product.repository.CategoryRepository;
+import com.pawbridge.storeservice.domain.product.repository.ProductRepository;
+import com.pawbridge.storeservice.domain.product.repository.ProductSKURepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.pawbridge.storeservice.domain.product.dto.ProductDetailResponse;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,15 +23,15 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ProductServiceImpl implements ProductService {
 
-    // Repository 의존성 (6개)
+    // Repository 의존성 (4개)
     private final ProductRepository productRepository;
     private final CategoryRepository categoryRepository;
-    private final OptionGroupRepository optionGroupRepository;
-    private final OptionValueRepository optionValueRepository;
     private final ProductSKURepository productSKURepository;
-    private final SKUValueRepository skuValueRepository;
+    private final CartItemRepository cartItemRepository;
     
-    // 분리된 서비스 의존성 (2개)
+    // 분리된 서비스 의존성 (4개)
+    private final ProductOptionService optionService;
+    private final ProductSKUService skuService;
     private final ProductOutboxService outboxService;
     private final ProductCacheService cacheService;
 
@@ -45,7 +43,7 @@ public class ProductServiceImpl implements ProductService {
                 .name(request.getName())
                 .description(request.getDescription())
                 .imageUrl(request.getImageUrl())
-                .status(ProductStatus.ACTIVE) // 기본 상태
+                .status(ProductStatus.ACTIVE)
                 .build();
 
         if (request.getCategoryId() != null) {
@@ -56,84 +54,20 @@ public class ProductServiceImpl implements ProductService {
 
         product = productRepository.save(product);
 
-        // "그룹명:값명"으로 OptionValue 엔티티를 찾기 위한 맵
-        Map<String, OptionValue> optionValueMap = new HashMap<>();
+        // 2. 옵션 그룹 및 옵션 값 저장 (위임)
+        Map<String, OptionValue> optionValueMap = optionService.createOptions(
+                product, request.getOptionGroups());
 
-        // 2. 옵션 그룹 및 옵션 값 저장
-        if (request.getOptionGroups() != null) {
-            for (OptionGroupCreateDto groupDto : request.getOptionGroups()) {
-                OptionGroup group = OptionGroup.builder()
-                        .product(product)
-                        .name(groupDto.getName())
-                        .build();
-                optionGroupRepository.save(group);
-
-                for (String valName : groupDto.getValues()) {
-                    OptionValue value = OptionValue.builder()
-                            .optionGroup(group)
-                            .name(valName)
-                            .build();
-                    optionValueRepository.save(value);
-                    optionValueMap.put(groupDto.getName() + ":" + valName, value);
-                }
-            }
-        }
-
-        // 집계를 위한 변수 (로직이 변경되었지만 안전/미래 사용을 위해 유지)
-        List<ProductSKU> tempSavedSkus = new ArrayList<>();
-
-        // 3. SKU 저장 및 옵션 값과 연결
-        if (request.getSkus() != null && !request.getSkus().isEmpty()) {
-            for (SkuCreateDto skuDto : request.getSkus()) {
-                // 3-1. SKU 저장
-                ProductSKU sku = ProductSKU.builder()
-                        .product(product)
-                        .skuCode(skuDto.getSkuCode())
-                        .price(skuDto.getPrice())
-                        .stockQuantity(skuDto.getStockQuantity())
-                        .build();
-                productSKURepository.save(sku);
-                
-                // Outbox 생성을 위해 임시 리스트에 추가
-                tempSavedSkus.add(sku);
-                // [Fix] Response 생성을 위해 Product 객체의 List에도 추가
-                product.getSkus().add(sku);
-
-                // 3-2. 옵션 연결 (SKUValue)
-                if (skuDto.getOptions() != null) {
-                    for (Map.Entry<String, String> entry : skuDto.getOptions().entrySet()) {
-                        String key = entry.getKey() + ":" + entry.getValue();
-                        OptionValue optionValue = optionValueMap.get(key);
-                        if (optionValue == null) {
-                            throw new IllegalArgumentException("SKU 내 유효하지 않은 옵션 값입니다: " + key);
-                        }
-                        SKUValue skuValue = SKUValue.builder()
-                                .productSKU(sku)
-                                .optionValue(optionValue)
-                                .build();
-                        skuValueRepository.save(skuValue);
-                        // [Fix] Outbox 생성을 위해 즉시 사용할 수 있도록 메모리 리스트에 추가
-                        sku.getSkuValues().add(skuValue);
-                    }
-                }
-            }
-        }
+        // 3. SKU 저장 및 옵션 값과 연결 (위임)
+        List<ProductSKU> savedSkus = skuService.createSkus(
+                product, request.getSkus(), optionValueMap);
 
         ProductResponse response = ProductResponse.from(product);
 
-        // 4. Outbox 이벤트 생성 (문서당 SKU 하나)
-        if (!tempSavedSkus.isEmpty()) {
-            // 대표 SKU 찾기 로직: 최저가 -> 동일하면 낮은 ID
-            ProductSKU primarySku = tempSavedSkus.stream()
-                .min((s1, s2) -> {
-                    int priceCompare = s1.getPrice().compareTo(s2.getPrice());
-                    if (priceCompare != 0) return priceCompare;
-                    if (s1.getId() == null || s2.getId() == null) return 0; 
-                    return s1.getId().compareTo(s2.getId());
-                })
-                .orElse(tempSavedSkus.get(0));
-
-            for (ProductSKU sku : tempSavedSkus) {
+        // 4. Outbox 이벤트 생성
+        if (!savedSkus.isEmpty()) {
+            ProductSKU primarySku = skuService.findPrimarySku(savedSkus);
+            for (ProductSKU sku : savedSkus) {
                 boolean isPrimary = (sku == primarySku);
                 outboxService.publishSkuEvent(product, sku, isPrimary);
             }
@@ -147,8 +81,6 @@ public class ProductServiceImpl implements ProductService {
     public ProductDetailResponse getProductDetails(Long productId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("Product not found: " + productId));
-        
-        // DTO 변환 시 지연 로딩(Lazy Loading)으로 SKUs와 OptionValues를 가져옴
         return ProductDetailResponse.from(product);
     }
 
@@ -175,7 +107,6 @@ public class ProductServiceImpl implements ProductService {
             for (SkuUpdateDto skuDto : request.getSkus()) {
                if (skuDto.getId() == null) continue;
                
-               // 단순 리스트에서 매칭되는 SKU 찾기
                product.getSkus().stream()
                    .filter(sku -> sku.getId().equals(skuDto.getId()))
                    .findFirst()
@@ -227,12 +158,18 @@ public class ProductServiceImpl implements ProductService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("Product not found: " + productId));
         
-        // SKU 삭제 이벤트 발행 (ES에서 제거하기 위함)
+        // 장바구니에 담긴 상품인지 확인
+        List<Long> skuIds = product.getSkus().stream()
+                .map(ProductSKU::getId)
+                .toList();
+        if (!skuIds.isEmpty() && cartItemRepository.existsByProductSkuIdIn(skuIds)) {
+            throw new IllegalStateException("장바구니에 담긴 상품은 삭제할 수 없습니다. 상품 ID: " + productId);
+        }
+        
+        // SKU 삭제 이벤트 발행 및 SKUValue 삭제 (위임)
         for (ProductSKU sku : product.getSkus()) {
             outboxService.publishSkuDeleteEvent(sku.getId());
-            // SKUValue를 먼저 명시적으로 삭제 (OptionValue 참조 해제)
-            skuValueRepository.deleteAll(sku.getSkuValues());
-            sku.getSkuValues().clear();
+            skuService.deleteSkuValues(sku);
         }
         
         // 상품 삭제 (CASCADE로 SKU, OptionGroup 등 함께 삭제)


### PR DESCRIPTION
## 변경 사항
카테고리 삭제 API를 추가하고, ProductServiceImpl의 책임을 분리하여 유지보수성을 개선했습니다.

### 주요 변경
#### 1. 카테고리 삭제 API
- `DELETE /api/categories/{categoryId}` 엔드포인트 추가
- 하위 카테고리가 있으면 삭제 불가 처리

#### 2. ProductServiceImpl 리팩토링
- **ProductOptionService** (NEW): OptionGroup, OptionValue 생성 로직 분리
- **ProductSKUService** (NEW): SKU 생성, 대표 SKU 찾기, SKUValue 삭제 로직 분리
- 코드량: 246줄 → 181줄

#### 3. 상품 삭제 방어 로직
- 장바구니에 담긴 상품 삭제 불가 처리
- `CartItemRepository.existsByProductSkuIdIn()` 추가

## 작업 유형
- [x] 새로운 기능 추가
- [x] 리팩토링
- [x] 문서 수정
- [ ] 버그 수정
- [ ] 테스트 추가

## 관련 이슈
Closes #94 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트 완료
- [x] 문서가 업데이트됨 (store-service-api.md)

## 향후 개선 사항
- [ ] 상품 Soft Delete 구현 (별도 이슈)