### PR TITLE
feat: 상품 찜 API 구현

### DIFF
--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/mypage/repository/MyWishlistRepository.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/mypage/repository/MyWishlistRepository.java
@@ -7,27 +7,34 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 /**
  * 위시리스트 Repository
- * - 마이페이지용
+ * - 마이페이지용 + 찜 추가/삭제
  */
 @Repository
 public interface MyWishlistRepository extends JpaRepository<Wishlist, Long> {
 
     /**
      * 사용자별 찜 목록 조회 (Product fetch join)
-     * - N+1 방지를 위해 @EntityGraph 사용
-     * @param userId 사용자 ID
-     * @param pageable 페이징 정보
-     * @return Page<Wishlist>
      */
     @EntityGraph(attributePaths = {"product", "product.category"})
     Page<Wishlist> findByUserId(Long userId, Pageable pageable);
 
     /**
      * 사용자별 찜 개수
-     * @param userId 사용자 ID
-     * @return 찜 개수
      */
     long countByUserId(Long userId);
+
+    /**
+     * 중복 찜 확인
+     */
+    boolean existsByUserIdAndProductId(Long userId, Long productId);
+
+    /**
+     * 찜 조회 (삭제용)
+     */
+    Optional<Wishlist> findByUserIdAndProductId(Long userId, Long productId);
 }
+

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/controller/WishlistController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/controller/WishlistController.java
@@ -1,0 +1,52 @@
+package com.pawbridge.storeservice.domain.wishlist.controller;
+
+import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddRequest;
+import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddResponse;
+import com.pawbridge.storeservice.domain.wishlist.service.WishlistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 상품 찜(Wishlist) API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/wishlists")
+@RequiredArgsConstructor
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    /**
+     * 찜 추가
+     * POST /api/wishlists
+     */
+    @PostMapping
+    public ResponseEntity<WishlistAddResponse> addWishlist(@RequestBody WishlistAddRequest request) {
+        WishlistAddResponse response = wishlistService.addWishlist(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 찜 삭제 (wishlistId로)
+     * DELETE /api/wishlists/{wishlistId}
+     */
+    @DeleteMapping("/{wishlistId}")
+    public ResponseEntity<Void> removeWishlist(@PathVariable Long wishlistId) {
+        wishlistService.removeWishlist(wishlistId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 찜 삭제 (userId + productId로)
+     * DELETE /api/wishlists?userId={userId}&productId={productId}
+     */
+    @DeleteMapping
+    public ResponseEntity<Void> removeWishlistByUserAndProduct(
+            @RequestParam Long userId,
+            @RequestParam Long productId) {
+        wishlistService.removeWishlistByUserAndProduct(userId, productId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddRequest.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddRequest.java
@@ -1,0 +1,13 @@
+package com.pawbridge.storeservice.domain.wishlist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WishlistAddRequest {
+    private Long userId;
+    private Long productId;
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddResponse.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddResponse.java
@@ -1,0 +1,27 @@
+package com.pawbridge.storeservice.domain.wishlist.dto;
+
+import com.pawbridge.storeservice.domain.product.entity.Wishlist;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class WishlistAddResponse {
+    private Long wishlistId;
+    private Long userId;
+    private Long productId;
+    private String productName;
+    private LocalDateTime createdAt;
+
+    public static WishlistAddResponse from(Wishlist wishlist) {
+        return WishlistAddResponse.builder()
+                .wishlistId(wishlist.getId())
+                .userId(wishlist.getUserId())
+                .productId(wishlist.getProduct().getId())
+                .productName(wishlist.getProduct().getName())
+                .createdAt(wishlist.getCreatedAt())
+                .build();
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistService.java
@@ -1,0 +1,22 @@
+package com.pawbridge.storeservice.domain.wishlist.service;
+
+import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddRequest;
+import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddResponse;
+
+public interface WishlistService {
+    
+    /**
+     * 찜 추가
+     */
+    WishlistAddResponse addWishlist(WishlistAddRequest request);
+    
+    /**
+     * 찜 삭제 (wishlistId로)
+     */
+    void removeWishlist(Long wishlistId);
+    
+    /**
+     * 찜 삭제 (userId + productId로)
+     */
+    void removeWishlistByUserAndProduct(Long userId, Long productId);
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistServiceImpl.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistServiceImpl.java
@@ -1,0 +1,65 @@
+package com.pawbridge.storeservice.domain.wishlist.service;
+
+import com.pawbridge.storeservice.domain.mypage.repository.MyWishlistRepository;
+import com.pawbridge.storeservice.domain.product.entity.Product;
+import com.pawbridge.storeservice.domain.product.entity.Wishlist;
+import com.pawbridge.storeservice.domain.product.repository.ProductRepository;
+import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddRequest;
+import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WishlistServiceImpl implements WishlistService {
+
+    private final MyWishlistRepository wishlistRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    @Transactional
+    public WishlistAddResponse addWishlist(WishlistAddRequest request) {
+        // 중복 찜 확인
+        if (wishlistRepository.existsByUserIdAndProductId(request.getUserId(), request.getProductId())) {
+            throw new IllegalStateException("이미 찜한 상품입니다.");
+        }
+
+        // 상품 존재 확인
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + request.getProductId()));
+
+        // 찜 저장
+        Wishlist wishlist = Wishlist.builder()
+                .userId(request.getUserId())
+                .product(product)
+                .build();
+        wishlistRepository.save(wishlist);
+
+        log.info(">>> [WISHLIST] 찜 추가: userId={}, productId={}", request.getUserId(), request.getProductId());
+
+        return WishlistAddResponse.from(wishlist);
+    }
+
+    @Override
+    @Transactional
+    public void removeWishlist(Long wishlistId) {
+        Wishlist wishlist = wishlistRepository.findById(wishlistId)
+                .orElseThrow(() -> new IllegalArgumentException("찜을 찾을 수 없습니다: " + wishlistId));
+        
+        wishlistRepository.delete(wishlist);
+        log.info(">>> [WISHLIST] 찜 삭제: wishlistId={}", wishlistId);
+    }
+
+    @Override
+    @Transactional
+    public void removeWishlistByUserAndProduct(Long userId, Long productId) {
+        Wishlist wishlist = wishlistRepository.findByUserIdAndProductId(userId, productId)
+                .orElseThrow(() -> new IllegalArgumentException("찜을 찾을 수 없습니다."));
+        
+        wishlistRepository.delete(wishlist);
+        log.info(">>> [WISHLIST] 찜 삭제: userId={}, productId={}", userId, productId);
+    }
+}


### PR DESCRIPTION
## 변경 사항
상품 찜하기 기능(분리형)을 구현했습니다.

### 주요 변경
- POST /api/wishlists (찜 추가)
- DELETE /api/wishlists/{wishlistId} (찜 삭제)
- DELETE /api/wishlists?userId&productId (찜 삭제)
- 중복 찜 방지 로직

### 참고
- S3 이미지 업로드는 이미 구현되어 있음 확인

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 버그 수정
- [ ] 테스트 추가

## 관련 이슈
Closes #96 

## 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료 (찜 추가/삭제)
- [x] API 명세 업데이트