### PR TITLE
feat: 주문 내역 및 상세 조회 API 구현

### DIFF
--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/controller/OrderController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/controller/OrderController.java
@@ -3,8 +3,12 @@ package com.pawbridge.storeservice.domain.order.controller;
 import com.pawbridge.storeservice.domain.order.dto.DirectOrderCreateRequest;
 import com.pawbridge.storeservice.domain.order.dto.OrderCreateRequest;
 import com.pawbridge.storeservice.domain.order.dto.OrderResponse;
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
 import com.pawbridge.storeservice.domain.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,9 +42,26 @@ public class OrderController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 주문 상세 조회 (본인 주문만)
+     */
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderResponse> getOrder(@PathVariable Long orderId) {
-        OrderResponse response = orderService.getOrder(orderId);
+    public ResponseEntity<OrderResponse> getOrder(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long orderId) {
+        OrderResponse response = orderService.getOrder(orderId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 내 주문 내역 조회 (페이징)
+     */
+    @GetMapping
+    public ResponseEntity<Page<OrderResponse>> getMyOrders(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestParam(required = false) OrderStatus status,
+            @PageableDefault(size = 10) Pageable pageable) {
+        Page<OrderResponse> response = orderService.getOrdersByUserId(userId, status, pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -50,3 +71,4 @@ public class OrderController {
         return ResponseEntity.ok().build();
     }
 }
+

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/repository/OrderRepository.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/repository/OrderRepository.java
@@ -1,13 +1,20 @@
 package com.pawbridge.storeservice.domain.order.repository;
 
 import com.pawbridge.storeservice.domain.order.entity.Order;
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findByUserId(Long userId);
     Optional<Order> findByOrderUuid(String orderUuid);
+    
+    // 페이징 조회
+    Page<Order> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    Page<Order> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, OrderStatus status, Pageable pageable);
 }
+

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/service/OrderService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/service/OrderService.java
@@ -3,12 +3,17 @@ package com.pawbridge.storeservice.domain.order.service;
 import com.pawbridge.storeservice.domain.order.dto.DirectOrderCreateRequest;
 import com.pawbridge.storeservice.domain.order.dto.OrderCreateRequest;
 import com.pawbridge.storeservice.domain.order.dto.OrderResponse;
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
     OrderResponse createOrder(Long userId, OrderCreateRequest request);
     OrderResponse createDirectOrder(Long userId, DirectOrderCreateRequest request);
-    OrderResponse getOrder(Long orderId);
+    OrderResponse getOrder(Long orderId, Long userId);
     OrderResponse getOrderByUuid(String orderUuid);
+    Page<OrderResponse> getOrdersByUserId(Long userId, OrderStatus status, Pageable pageable);
     void processPayment(Long orderId);
     void cancelOrder(String orderUuid);
 }
+


### PR DESCRIPTION
## 변경 사항
마이페이지에서 사용자의 주문 내역을 조회할 수 있는 API를 구현했습니다.

### 신규 API
- `GET /api/orders` - 내 주문 목록 조회 (페이징, 상태 필터)

### 개선 사항
- `GET /api/orders/{orderId}` - 본인 주문만 조회 가능하도록 보안 강화

### 변경 파일
- OrderController.java
- OrderService.java
- OrderServiceImpl.java
- OrderRepository.java
- store-service-api.md

## 작업 유형
- [x] 새로운 기능 추가
- [x] 보안 개선
- [x] 문서 수정

## 테스트
- [x] 빌드 성공
- [x] E2E 테스트 완료 (옵션→상품→장바구니→주문→조회)

## 관련 이슈
Closes #101 