### PR TITLE
refactor: SKU 기반으로 찜 기능 리팩토링

### DIFF
--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/mypage/dto/WishlistResponse.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/mypage/dto/WishlistResponse.java
@@ -1,5 +1,7 @@
 package com.pawbridge.storeservice.domain.mypage.dto;
 
+import com.pawbridge.storeservice.domain.product.entity.ProductSKU;
+import com.pawbridge.storeservice.domain.product.entity.SKUValue;
 import com.pawbridge.storeservice.domain.product.entity.Wishlist;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,10 +9,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 찜 목록 응답 DTO
  * - 마이페이지용
+ * - SKU 기반 (가격, 옵션 정보 포함)
  */
 @Data
 @Builder
@@ -19,27 +24,46 @@ import java.time.LocalDateTime;
 public class WishlistResponse {
 
     private Long wishlistId;
+    private Long skuId;
+    private String skuCode;
     private Long productId;
     private String productName;
     private String productDescription;
     private String productImageUrl;
     private String productStatus;
+    private Long price;
+    private Map<String, String> options;
     private Long categoryId;
     private String categoryName;
     private LocalDateTime createdAt;
 
     public static WishlistResponse from(Wishlist wishlist) {
+        ProductSKU sku = wishlist.getSku();
+        
+        // 옵션 정보 추출
+        Map<String, String> optionMap = new HashMap<>();
+        for (SKUValue skuValue : sku.getSkuValues()) {
+            optionMap.put(
+                skuValue.getOptionValue().getOptionGroup().getName(),
+                skuValue.getOptionValue().getName()
+            );
+        }
+        
         return WishlistResponse.builder()
                 .wishlistId(wishlist.getId())
-                .productId(wishlist.getProduct().getId())
-                .productName(wishlist.getProduct().getName())
-                .productDescription(wishlist.getProduct().getDescription())
-                .productImageUrl(wishlist.getProduct().getImageUrl())
-                .productStatus(wishlist.getProduct().getStatus().name())
-                .categoryId(wishlist.getProduct().getCategory() != null ?
-                        wishlist.getProduct().getCategory().getId() : null)
-                .categoryName(wishlist.getProduct().getCategory() != null ?
-                        wishlist.getProduct().getCategory().getName() : null)
+                .skuId(sku.getId())
+                .skuCode(sku.getSkuCode())
+                .productId(sku.getProduct().getId())
+                .productName(sku.getProduct().getName())
+                .productDescription(sku.getProduct().getDescription())
+                .productImageUrl(sku.getProduct().getImageUrl())
+                .productStatus(sku.getProduct().getStatus().name())
+                .price(sku.getPrice())
+                .options(optionMap)
+                .categoryId(sku.getProduct().getCategory() != null ?
+                        sku.getProduct().getCategory().getId() : null)
+                .categoryName(sku.getProduct().getCategory() != null ?
+                        sku.getProduct().getCategory().getName() : null)
                 .createdAt(wishlist.getCreatedAt())
                 .build();
     }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/mypage/repository/MyWishlistRepository.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/mypage/repository/MyWishlistRepository.java
@@ -12,14 +12,15 @@ import java.util.Optional;
 /**
  * 위시리스트 Repository
  * - 마이페이지용 + 찜 추가/삭제
+ * - SKU 기반
  */
 @Repository
 public interface MyWishlistRepository extends JpaRepository<Wishlist, Long> {
 
     /**
-     * 사용자별 찜 목록 조회 (Product fetch join)
+     * 사용자별 찜 목록 조회 (SKU, Product, Category fetch join)
      */
-    @EntityGraph(attributePaths = {"product", "product.category"})
+    @EntityGraph(attributePaths = {"sku", "sku.product", "sku.product.category", "sku.skuValues", "sku.skuValues.optionValue", "sku.skuValues.optionValue.optionGroup"})
     Page<Wishlist> findByUserId(Long userId, Pageable pageable);
 
     /**
@@ -28,13 +29,12 @@ public interface MyWishlistRepository extends JpaRepository<Wishlist, Long> {
     long countByUserId(Long userId);
 
     /**
-     * 중복 찜 확인
+     * 중복 찜 확인 (SKU 기반)
      */
-    boolean existsByUserIdAndProductId(Long userId, Long productId);
+    boolean existsByUserIdAndSkuId(Long userId, Long skuId);
 
     /**
-     * 찜 조회 (삭제용)
+     * 찜 조회 (삭제용, SKU 기반)
      */
-    Optional<Wishlist> findByUserIdAndProductId(Long userId, Long productId);
+    Optional<Wishlist> findByUserIdAndSkuId(Long userId, Long skuId);
 }
-

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/entity/Wishlist.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/entity/Wishlist.java
@@ -21,12 +21,12 @@ public class Wishlist extends BaseEntity {
     private Long userId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false)
-    private Product product;
+    @JoinColumn(name = "sku_id", nullable = false)
+    private ProductSKU sku;
 
     @Builder
-    public Wishlist(Long userId, Product product) {
+    public Wishlist(Long userId, ProductSKU sku) {
         this.userId = userId;
-        this.product = product;
+        this.sku = sku;
     }
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/controller/WishlistController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/controller/WishlistController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 /**
  * 상품 찜(Wishlist) API 컨트롤러
+ * - SKU 기반
  */
 @RestController
 @RequestMapping("/api/wishlists")
@@ -19,7 +20,7 @@ public class WishlistController {
     private final WishlistService wishlistService;
 
     /**
-     * 찜 추가
+     * 찜 추가 (SKU 기반)
      * POST /api/wishlists
      */
     @PostMapping
@@ -39,14 +40,14 @@ public class WishlistController {
     }
 
     /**
-     * 찜 삭제 (userId + productId로)
-     * DELETE /api/wishlists?userId={userId}&productId={productId}
+     * 찜 삭제 (userId + skuId로)
+     * DELETE /api/wishlists?userId={userId}&skuId={skuId}
      */
     @DeleteMapping
-    public ResponseEntity<Void> removeWishlistByUserAndProduct(
+    public ResponseEntity<Void> removeWishlistByUserAndSku(
             @RequestParam Long userId,
-            @RequestParam Long productId) {
-        wishlistService.removeWishlistByUserAndProduct(userId, productId);
+            @RequestParam Long skuId) {
+        wishlistService.removeWishlistByUserAndSku(userId, skuId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddRequest.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddRequest.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class WishlistAddRequest {
     private Long userId;
-    private Long productId;
+    private Long skuId;
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddResponse.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/dto/WishlistAddResponse.java
@@ -1,26 +1,51 @@
 package com.pawbridge.storeservice.domain.wishlist.dto;
 
+import com.pawbridge.storeservice.domain.product.entity.ProductSKU;
+import com.pawbridge.storeservice.domain.product.entity.SKUValue;
 import com.pawbridge.storeservice.domain.product.entity.Wishlist;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @Getter
 @Builder
 public class WishlistAddResponse {
     private Long wishlistId;
     private Long userId;
+    private Long skuId;
+    private String skuCode;
     private Long productId;
     private String productName;
+    private String productImageUrl;
+    private Long price;
+    private Map<String, String> options;
     private LocalDateTime createdAt;
 
     public static WishlistAddResponse from(Wishlist wishlist) {
+        ProductSKU sku = wishlist.getSku();
+        
+        // 옵션 정보 추출
+        Map<String, String> optionMap = new HashMap<>();
+        for (SKUValue skuValue : sku.getSkuValues()) {
+            optionMap.put(
+                skuValue.getOptionValue().getOptionGroup().getName(),
+                skuValue.getOptionValue().getName()
+            );
+        }
+        
         return WishlistAddResponse.builder()
                 .wishlistId(wishlist.getId())
                 .userId(wishlist.getUserId())
-                .productId(wishlist.getProduct().getId())
-                .productName(wishlist.getProduct().getName())
+                .skuId(sku.getId())
+                .skuCode(sku.getSkuCode())
+                .productId(sku.getProduct().getId())
+                .productName(sku.getProduct().getName())
+                .productImageUrl(sku.getProduct().getImageUrl())
+                .price(sku.getPrice())
+                .options(optionMap)
                 .createdAt(wishlist.getCreatedAt())
                 .build();
     }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistService.java
@@ -6,7 +6,7 @@ import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddResponse;
 public interface WishlistService {
     
     /**
-     * 찜 추가
+     * 찜 추가 (SKU 기반)
      */
     WishlistAddResponse addWishlist(WishlistAddRequest request);
     
@@ -16,7 +16,7 @@ public interface WishlistService {
     void removeWishlist(Long wishlistId);
     
     /**
-     * 찜 삭제 (userId + productId로)
+     * 찜 삭제 (userId + skuId로)
      */
-    void removeWishlistByUserAndProduct(Long userId, Long productId);
+    void removeWishlistByUserAndSku(Long userId, Long skuId);
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistServiceImpl.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/service/WishlistServiceImpl.java
@@ -1,9 +1,9 @@
 package com.pawbridge.storeservice.domain.wishlist.service;
 
 import com.pawbridge.storeservice.domain.mypage.repository.MyWishlistRepository;
-import com.pawbridge.storeservice.domain.product.entity.Product;
+import com.pawbridge.storeservice.domain.product.entity.ProductSKU;
 import com.pawbridge.storeservice.domain.product.entity.Wishlist;
-import com.pawbridge.storeservice.domain.product.repository.ProductRepository;
+import com.pawbridge.storeservice.domain.product.repository.ProductSKURepository;
 import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddRequest;
 import com.pawbridge.storeservice.domain.wishlist.dto.WishlistAddResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,28 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class WishlistServiceImpl implements WishlistService {
 
     private final MyWishlistRepository wishlistRepository;
-    private final ProductRepository productRepository;
+    private final ProductSKURepository skuRepository;
 
     @Override
     @Transactional
     public WishlistAddResponse addWishlist(WishlistAddRequest request) {
-        // 중복 찜 확인
-        if (wishlistRepository.existsByUserIdAndProductId(request.getUserId(), request.getProductId())) {
+        // 중복 찜 확인 (동일 사용자 + 동일 SKU)
+        if (wishlistRepository.existsByUserIdAndSkuId(request.getUserId(), request.getSkuId())) {
             throw new IllegalStateException("이미 찜한 상품입니다.");
         }
 
-        // 상품 존재 확인
-        Product product = productRepository.findById(request.getProductId())
-                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + request.getProductId()));
+        // SKU 존재 확인
+        ProductSKU sku = skuRepository.findById(request.getSkuId())
+                .orElseThrow(() -> new IllegalArgumentException("SKU를 찾을 수 없습니다: " + request.getSkuId()));
 
         // 찜 저장
         Wishlist wishlist = Wishlist.builder()
                 .userId(request.getUserId())
-                .product(product)
+                .sku(sku)
                 .build();
         wishlistRepository.save(wishlist);
 
-        log.info(">>> [WISHLIST] 찜 추가: userId={}, productId={}", request.getUserId(), request.getProductId());
+        log.info(">>> [WISHLIST] 찜 추가: userId={}, skuId={}", request.getUserId(), request.getSkuId());
 
         return WishlistAddResponse.from(wishlist);
     }
@@ -55,11 +55,11 @@ public class WishlistServiceImpl implements WishlistService {
 
     @Override
     @Transactional
-    public void removeWishlistByUserAndProduct(Long userId, Long productId) {
-        Wishlist wishlist = wishlistRepository.findByUserIdAndProductId(userId, productId)
+    public void removeWishlistByUserAndSku(Long userId, Long skuId) {
+        Wishlist wishlist = wishlistRepository.findByUserIdAndSkuId(userId, skuId)
                 .orElseThrow(() -> new IllegalArgumentException("찜을 찾을 수 없습니다."));
         
         wishlistRepository.delete(wishlist);
-        log.info(">>> [WISHLIST] 찜 삭제: userId={}, productId={}", userId, productId);
+        log.info(">>> [WISHLIST] 찜 삭제: userId={}, skuId={}", userId, skuId);
     }
 }


### PR DESCRIPTION
## 변경 사항
Wishlist를 Product 기반에서 SKU 기반으로 변경하여 사용자가 선택한 옵션(색상, 사이즈)과 가격 정보를 정확히 저장할 수 있도록 개선

### 엔티티
- Wishlist: Product -> ProductSKU 연관관계 변경

### DTO
- WishlistAddRequest: productId -> skuId
- WishlistAddResponse: 가격, 옵션 정보 추가
- WishlistResponse: 가격, 옵션 정보 추가

### Service/Repository
- WishlistService: removeWishlistByUserAndProduct -> removeWishlistByUserAndSku
- MyWishlistRepository: SKU 기반 쿼리 메서드 추가


## 작업 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #110 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
DB 변경 사항: wishlists 테이블의 product_id 컬럼이 sku_id로 변경됨