### PR TITLE
feat: 관리자 주문 관리 API 및 v1 버저닝 적용

### DIFF
--- a/api-gateway/src/main/java/com/pawbridge/apigateway/filter/JwtAuthorizationGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/filter/JwtAuthorizationGatewayFilterFactory.java
@@ -47,10 +47,26 @@ public class JwtAuthorizationGatewayFilterFactory
             "/api/v1/comments/posts/read/*"        // 특정 게시글 댓글 목록 조회
     );
 
-    // ROLE_ADMIN만 접근 가능한 경로
+    // ROLE_ADMIN만 접근 가능한 경로 (프론트엔드 요청 기준, v1 없음)
     private static final List<String> ADMIN_ONLY_PATHS = List.of(
             "POST:/api/v1/shelters",               // 보호소 등록
-            "DELETE:/api/v1/shelters/*"            // 보호소 삭제
+            "DELETE:/api/v1/shelters/*",           // 보호소 삭제
+            // Store Service 관리자 API (프론트 요청 기준)
+            "POST:/api/products",                  // 상품 등록
+            "PATCH:/api/products/*",               // 상품 수정
+            "DELETE:/api/products/*",              // 상품 삭제
+            "POST:/api/categories",                // 카테고리 등록
+            "PUT:/api/categories/*",               // 카테고리 수정
+            "DELETE:/api/categories/*",            // 카테고리 삭제
+            "POST:/api/option-groups",             // 옵션 그룹 등록
+            "PUT:/api/option-groups/*",            // 옵션 그룹 수정
+            "DELETE:/api/option-groups/*",         // 옵션 그룹 삭제
+            "POST:/api/option-groups/*/values",    // 옵션 값 추가
+            "PUT:/api/option-groups/values/*",     // 옵션 값 수정
+            "DELETE:/api/option-groups/values/*",  // 옵션 값 삭제
+            "GET:/api/admin/orders",               // 관리자 주문 목록
+            "PATCH:/api/admin/orders/*/status",    // 주문 상태 변경
+            "PATCH:/api/admin/orders/*/delivery-status"  // 배송 상태 변경
     );
 
     // ROLE_USER가 아닐 때 접근 가능한 경로 (ROLE_ADMIN, ROLE_SHELTER)

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/cart/controller/CartController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/cart/controller/CartController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/carts")
+@RequestMapping("/api/v1/carts")
 @RequiredArgsConstructor
 public class CartController {
 

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/image/controller/ImageController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/image/controller/ImageController.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/images")
+@RequestMapping("/api/v1/images")
 @RequiredArgsConstructor
 public class ImageController {
 

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/option/controller/OptionController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/option/controller/OptionController.java
@@ -17,7 +17,7 @@ import java.util.List;
  * - 옵션 그룹/값 CRUD
  */
 @RestController
-@RequestMapping("/api/option-groups")
+@RequestMapping("/api/v1/option-groups")
 @RequiredArgsConstructor
 public class OptionController {
 

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/controller/AdminOrderController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/controller/AdminOrderController.java
@@ -1,0 +1,67 @@
+package com.pawbridge.storeservice.domain.order.controller;
+
+import com.pawbridge.storeservice.domain.order.dto.DeliveryStatusUpdateRequest;
+import com.pawbridge.storeservice.domain.order.dto.OrderResponse;
+import com.pawbridge.storeservice.domain.order.dto.OrderStatusUpdateRequest;
+import com.pawbridge.storeservice.domain.order.entity.DeliveryStatus;
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
+import com.pawbridge.storeservice.domain.order.service.AdminOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 관리자용 주문 관리 API
+ */
+@RestController
+@RequestMapping("/api/v1/admin/orders")
+@RequiredArgsConstructor
+public class AdminOrderController {
+
+    private final AdminOrderService adminOrderService;
+
+    /**
+     * 전체 주문 목록 조회 (관리자용)
+     * - 필터링: status, deliveryStatus, userId
+     * - 검색: keyword (주문번호, 수령인 이름)
+     * - 정렬: sortBy, sortOrder
+     */
+    @GetMapping
+    public ResponseEntity<Page<OrderResponse>> getAllOrders(
+            @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false) DeliveryStatus deliveryStatus,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+            @RequestParam(required = false, defaultValue = "desc") String sortOrder,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<OrderResponse> response = adminOrderService.getAllOrders(
+                status, deliveryStatus, userId, keyword, sortBy, sortOrder, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 주문 상태 변경 (관리자용)
+     */
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<OrderResponse> updateOrderStatus(
+            @PathVariable Long orderId,
+            @RequestBody OrderStatusUpdateRequest request) {
+        OrderResponse response = adminOrderService.updateOrderStatus(orderId, request.getStatus());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 배송 상태 변경 (관리자용)
+     */
+    @PatchMapping("/{orderId}/delivery-status")
+    public ResponseEntity<OrderResponse> updateDeliveryStatus(
+            @PathVariable Long orderId,
+            @RequestBody DeliveryStatusUpdateRequest request) {
+        OrderResponse response = adminOrderService.updateDeliveryStatus(orderId, request.getDeliveryStatus());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/controller/OrderController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/controller/OrderController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/orders")
+@RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
 public class OrderController {
 

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/dto/DeliveryStatusUpdateRequest.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/dto/DeliveryStatusUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.pawbridge.storeservice.domain.order.dto;
+
+import com.pawbridge.storeservice.domain.order.entity.DeliveryStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 배송 상태 변경 요청 DTO (관리자용)
+ */
+@Getter
+@NoArgsConstructor
+public class DeliveryStatusUpdateRequest {
+    private DeliveryStatus deliveryStatus;
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/dto/OrderResponse.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/dto/OrderResponse.java
@@ -14,8 +14,10 @@ import java.util.stream.Collectors;
 public class OrderResponse {
     private Long orderId;
     private String orderUuid;
+    private Long userId;
     private Long totalAmount;
     private String status;
+    private String deliveryStatus;
     private String receiverName;
     private String receiverPhone;
     private String deliveryAddress;
@@ -27,8 +29,10 @@ public class OrderResponse {
         return OrderResponse.builder()
                 .orderId(order.getId())
                 .orderUuid(order.getOrderUuid())
+                .userId(order.getUserId())
                 .totalAmount(order.getTotalAmount())
                 .status(order.getStatus().name())
+                .deliveryStatus(order.getDeliveryStatus().name())
                 .deliveryAddress(order.getDeliveryAddress())
                 .receiverName(order.getReceiverName())
                 .receiverPhone(order.getReceiverPhone())

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/dto/OrderStatusUpdateRequest.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/dto/OrderStatusUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.pawbridge.storeservice.domain.order.dto;
+
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문 상태 변경 요청 DTO (관리자용)
+ */
+@Getter
+@NoArgsConstructor
+public class OrderStatusUpdateRequest {
+    private OrderStatus status;
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/entity/Order.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/entity/Order.java
@@ -81,4 +81,18 @@ public class Order extends BaseEntity {
     public void updateTotalAmount(Long amount) {
         this.totalAmount = amount;
     }
+
+    /**
+     * 주문 상태 변경 (관리자용)
+     */
+    public void updateStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    /**
+     * 배송 상태 변경 (관리자용)
+     */
+    public void updateDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
 }

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/repository/OrderRepository.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/repository/OrderRepository.java
@@ -5,11 +5,12 @@ import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecificationExecutor<Order> {
     List<Order> findByUserId(Long userId);
     Optional<Order> findByOrderUuid(String orderUuid);
     

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/service/AdminOrderService.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/service/AdminOrderService.java
@@ -1,0 +1,35 @@
+package com.pawbridge.storeservice.domain.order.service;
+
+import com.pawbridge.storeservice.domain.order.dto.OrderResponse;
+import com.pawbridge.storeservice.domain.order.entity.DeliveryStatus;
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 관리자용 주문 관리 서비스
+ */
+public interface AdminOrderService {
+    
+    /**
+     * 전체 주문 목록 조회 (관리자용)
+     */
+    Page<OrderResponse> getAllOrders(
+            OrderStatus status, 
+            DeliveryStatus deliveryStatus, 
+            Long userId,
+            String keyword,
+            String sortBy,
+            String sortOrder,
+            Pageable pageable);
+    
+    /**
+     * 주문 상태 변경 (관리자용)
+     */
+    OrderResponse updateOrderStatus(Long orderId, OrderStatus status);
+    
+    /**
+     * 배송 상태 변경 (관리자용)
+     */
+    OrderResponse updateDeliveryStatus(Long orderId, DeliveryStatus deliveryStatus);
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/order/service/AdminOrderServiceImpl.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/order/service/AdminOrderServiceImpl.java
@@ -1,0 +1,99 @@
+package com.pawbridge.storeservice.domain.order.service;
+
+import com.pawbridge.storeservice.domain.order.dto.OrderResponse;
+import com.pawbridge.storeservice.domain.order.entity.DeliveryStatus;
+import com.pawbridge.storeservice.domain.order.entity.Order;
+import com.pawbridge.storeservice.domain.order.entity.OrderStatus;
+import com.pawbridge.storeservice.domain.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자용 주문 관리 서비스 구현체
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminOrderServiceImpl implements AdminOrderService {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public Page<OrderResponse> getAllOrders(
+            OrderStatus status, 
+            DeliveryStatus deliveryStatus, 
+            Long userId,
+            String keyword,
+            String sortBy,
+            String sortOrder,
+            Pageable pageable) {
+        
+        Specification<Order> spec = Specification.where(null);
+        
+        // 상태 필터
+        if (status != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
+        }
+        
+        // 배송 상태 필터
+        if (deliveryStatus != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("deliveryStatus"), deliveryStatus));
+        }
+        
+        // 사용자 ID 필터
+        if (userId != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("userId"), userId));
+        }
+        
+        // 키워드 검색 (주문번호 또는 수령인 이름)
+        if (keyword != null && !keyword.isBlank()) {
+            String likePattern = "%" + keyword.toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                    cb.like(cb.lower(root.get("orderUuid")), likePattern),
+                    cb.like(cb.lower(root.get("receiverName")), likePattern)
+            ));
+        }
+        
+        // 정렬 적용
+        Sort sort = Sort.by(
+                "asc".equalsIgnoreCase(sortOrder) ? Sort.Direction.ASC : Sort.Direction.DESC,
+                sortBy
+        );
+        Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        
+        Page<Order> orders = orderRepository.findAll(spec, sortedPageable);
+        return orders.map(OrderResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public OrderResponse updateOrderStatus(Long orderId, OrderStatus status) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다. orderId: " + orderId));
+        
+        log.info("주문 상태 변경 - orderId: {}, {} -> {}", orderId, order.getStatus(), status);
+        order.updateStatus(status);
+        
+        return OrderResponse.from(order);
+    }
+
+    @Override
+    @Transactional
+    public OrderResponse updateDeliveryStatus(Long orderId, DeliveryStatus deliveryStatus) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다. orderId: " + orderId));
+        
+        log.info("배송 상태 변경 - orderId: {}, {} -> {}", orderId, order.getDeliveryStatus(), deliveryStatus);
+        order.updateDeliveryStatus(deliveryStatus);
+        
+        return OrderResponse.from(order);
+    }
+}

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/CategoryController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/CategoryController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/categories")
+@RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/ProductController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/product/controller/ProductController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/products")
+@RequestMapping("/api/v1/products")
 @RequiredArgsConstructor
 @Slf4j
 public class ProductController {

--- a/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/controller/WishlistController.java
+++ b/store-service/src/main/java/com/pawbridge/storeservice/domain/wishlist/controller/WishlistController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
  * - SKU 기반
  */
 @RestController
-@RequestMapping("/api/wishlists")
+@RequestMapping("/api/v1/wishlists")
 @RequiredArgsConstructor
 public class WishlistController {
 


### PR DESCRIPTION
## 변경 사항
### 1. 관리자 주문 관리 API 추가
#### GET /api/admin/orders - 전체 주문 목록 조회
관리자 대시보드에서 모든 사용자의 주문을 조회합니다.
- 필터링: status, deliveryStatus, userId
- 검색: keyword (주문번호, 수령인 이름으로 검색)
- 정렬: sortBy (createdAt, totalAmount, status), sortOrder (asc, desc)
- 페이징: page (기본 0), size (기본 20)

#### PATCH /api/admin/orders/{orderId}/status - 주문 상태 변경
관리자가 주문 상태를 수동으로 변경합니다.
- OrderStatus: PENDING, PAID, COMPLETED, CANCELLED, FAILED

#### PATCH /api/admin/orders/{orderId}/delivery-status - 배송 상태 변경
관리자가 배송 상태를 수동으로 변경합니다.
- DeliveryStatus: READY, SHIPPING, DELIVERED

---

### 2. Store Service API v1 버저닝
모든 컨트롤러에 v1 경로 적용:
- ProductController → /api/v1/products
- CategoryController → /api/v1/categories
- OptionController → /api/v1/option-groups
- CartController → /api/v1/carts
- OrderController → /api/v1/orders
- AdminOrderController → /api/v1/admin/orders
- WishlistController → /api/v1/wishlists
- ImageController → /api/v1/images

프론트엔드는 기존처럼 /api/xxx 형식으로 요청하고, API Gateway RewritePath로 v1 변환합니다.

---

### 3. API Gateway 설정
ADMIN_ONLY_PATHS에 Store Service 관리자 API 추가 (상품/카테고리/옵션 CUD, 관리자 주문 API)

---

### 4. API 명세서 업데이트

- 섹션 10에 관리자 주문 관리 API 문서화
- API 버저닝 설명 추가 (프론트엔드/백엔드 경로 차이)

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #112 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [x] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨

## 추가 설명
- 프론트엔드는 기존처럼 /api/xxx 형식으로 요청하면 됩니다
- 관리자 주문 API는 권한 필요