### PR TITLE
feat: animal-service S3 이미지 업로드 기능 구현

### DIFF
--- a/animal-service/build.gradle
+++ b/animal-service/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/config/S3Config.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.pawbridge.animalservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * AWS S3 클라이언트 설정
+ */
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/controller/ImageController.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/controller/ImageController.java
@@ -1,0 +1,104 @@
+package com.pawbridge.animalservice.controller;
+
+import com.pawbridge.animalservice.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 동물 이미지 업로드 API 컨트롤러
+ * - 단일/다중 이미지 업로드 지원
+ * - S3에 저장 후 URL 반환
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/animals/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final S3Service s3Service;
+
+    /**
+     * 단일 이미지 업로드
+     * POST /api/v1/animals/images
+     *
+     * @param file 업로드할 이미지 파일
+     * @return 업로드된 이미지 URL
+     */
+    @PostMapping
+    public ResponseEntity<Map<String, String>> uploadImage(
+            @RequestParam("file") MultipartFile file) {
+
+        log.info("이미지 업로드 요청: filename={}, size={}", 
+                file.getOriginalFilename(), file.getSize());
+
+        String imageUrl = s3Service.uploadImage(file);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("imageUrl", imageUrl);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 다중 이미지 업로드
+     * POST /api/v1/animals/images/multiple
+     *
+     * @param files 업로드할 이미지 파일들 (최대 5개)
+     * @return 업로드된 이미지 URL 목록
+     */
+    @PostMapping("/multiple")
+    public ResponseEntity<Map<String, Object>> uploadMultipleImages(
+            @RequestParam("files") MultipartFile[] files) {
+
+        if (files == null || files.length == 0) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+
+        if (files.length > 5) {
+            throw new IllegalArgumentException("최대 5개의 이미지만 업로드할 수 있습니다.");
+        }
+
+        log.info("다중 이미지 업로드 요청: count={}", files.length);
+
+        List<String> imageUrls = new ArrayList<>();
+        for (MultipartFile file : files) {
+            String imageUrl = s3Service.uploadImage(file);
+            imageUrls.add(imageUrl);
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("imageUrls", imageUrls);
+        response.put("count", imageUrls.size());
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 이미지 삭제
+     * DELETE /api/v1/animals/images
+     *
+     * @param imageUrl 삭제할 이미지 URL
+     * @return 성공 메시지
+     */
+    @DeleteMapping
+    public ResponseEntity<Map<String, String>> deleteImage(
+            @RequestParam("imageUrl") String imageUrl) {
+
+        log.info("이미지 삭제 요청: url={}", imageUrl);
+
+        s3Service.deleteImage(imageUrl);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "이미지가 삭제되었습니다.");
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/S3Service.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/S3Service.java
@@ -1,0 +1,157 @@
+package com.pawbridge.animalservice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * S3 이미지 업로드 서비스
+ * - 동물 이미지 업로드/삭제 기능 제공
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    private static final String ANIMALS_FOLDER = "animals/";
+
+    private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/gif",
+            "image/webp"
+    );
+
+    /**
+     * 이미지 업로드
+     * @param file 업로드할 이미지 파일
+     * @return 업로드된 이미지의 S3 URL
+     */
+    public String uploadImage(MultipartFile file) {
+        validateImageFile(file);
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = extractExtension(originalFilename);
+        
+        // S3 키: animals/{uuid}.{extension}
+        String key = ANIMALS_FOLDER + UUID.randomUUID() + extension;
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            String imageUrl = buildS3Url(key);
+            log.info("이미지 업로드 완료: {}", imageUrl);
+            return imageUrl;
+
+        } catch (IOException e) {
+            log.error("이미지 업로드 실패: {}", originalFilename, e);
+            throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 이미지 삭제
+     * @param imageUrl 삭제할 이미지의 S3 URL
+     */
+    public void deleteImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return;
+        }
+
+        // URL에서 S3 키 추출
+        String key = extractKeyFromUrl(imageUrl);
+        if (key == null) {
+            log.warn("유효하지 않은 이미지 URL: {}", imageUrl);
+            return;
+        }
+
+        try {
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteRequest);
+            log.info("이미지 삭제 완료: {}", key);
+
+        } catch (Exception e) {
+            log.error("이미지 삭제 실패: {}", key, e);
+            // 삭제 실패는 예외를 던지지 않음 (비즈니스 로직에 영향 없음)
+        }
+    }
+
+    /**
+     * 파일 유효성 검증
+     */
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_IMAGE_TYPES.contains(contentType.toLowerCase())) {
+            throw new IllegalArgumentException("허용되지 않는 파일 형식입니다. 허용: " + ALLOWED_IMAGE_TYPES);
+        }
+
+        // 파일 크기 제한 (10MB)
+        long maxSize = 10 * 1024 * 1024;
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String extractExtension(String filename) {
+        if (filename != null && filename.contains(".")) {
+            return filename.substring(filename.lastIndexOf("."));
+        }
+        return "";
+    }
+
+    /**
+     * S3 URL 생성
+     */
+    private String buildS3Url(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    /**
+     * S3 URL에서 키 추출
+     */
+    private String extractKeyFromUrl(String imageUrl) {
+        // https://{bucket}.s3.{region}.amazonaws.com/{key} 형식에서 key 추출
+        String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucketName, region);
+        if (imageUrl.startsWith(prefix)) {
+            return imageUrl.substring(prefix.length());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 변경 사항
Animal Service에 S3 이미지 업로드 기능을 추가했습니다.

### 구현 내용
**S3Config**
- AWS S3 클라이언트 Bean 설정
- Config Server에서 credentials, region, bucket 주입

**S3Service**
- uploadImage(): 단일 이미지 S3 업로드
- deleteImage(): S3 이미지 삭제
- 파일 타입 검증: JPEG, PNG, GIF, WebP만 허용
- 파일 크기 제한: 최대 10MB
- UUID 기반 파일명 생성으로 중복 방지
- 저장 경로: animals/{uuid}.{extension}

**ImageController**
- POST /api/v1/animals/images: 단일 이미지 업로드
- POST /api/v1/animals/images/multiple: 다중 이미지 업로드 (최대 5개)
- DELETE /api/v1/animals/images: 이미지 삭제

### 이미지 저장 전략
| 데이터 출처 | 저장 방식 | 이유 |
|------------|----------|------|
| APMS 배치 | 정부 서버 URL 그대로 저장 | 저장 비용 절감, 배치 단순화 |
| 수동 등록 | S3 업로드 후 URL 저장 | 안정적인 이미지 제공, 정부 서버 의존 제거 |

APMS 배치는 매일 수천 건의 데이터가 동기화되므로 모든 이미지를 S3로 미러링하면 저장 비용이 크게 증가합니다.
정부 서버(animal.go.kr)의 가용성이 높아 실질적 문제가 낮고, 필요 시 추후 미러링 기능 추가 가능합니다.

### 문서 업데이트
- animal-service-api.md: 이미지 업로드 API 섹션 추가
- animal-service.md: 서비스 개요 및 이미지 저장 전략 추가

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈

Closes #115

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)