### PR TITLE
feat: animal-service S3 이미지 업로드 기능 구현

### DIFF
--- a/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/CreateAnimalRequest.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/dto/request/CreateAnimalRequest.java
@@ -26,17 +26,19 @@ public class CreateAnimalRequest {
 
     // 필수 필드 (9개)
     /**
-     * 보호소 ID
+     * 보호소 등록번호
+     * - 예: "411310000001"
+     * - /api/users/me에서 careRegNo 획득
      */
-    @NotNull(message = "보호소 ID는 필수입니다")
-    private Long shelterId;
+    @NotBlank(message = "보호소 등록번호는 필수입니다")
+    @Size(max = 50, message = "보호소 등록번호는 50자 이하여야 합니다")
+    private String careRegNo;
 
     /**
-     * 공고번호
-     * - 예: "경기-양평-2025-00429"
-     * - UNIQUE 제약으로 중복 방지
+     * 공고번호 (선택)
+     * - APMS 데이터: 직접 입력 (예: "경기-양평-2025-00429")
+     * - 수동 등록: 미입력 시 자동 생성 (예: "MAN-251230-000001")
      */
-    @NotBlank(message = "공고번호는 필수입니다")
     @Size(max = 100, message = "공고번호는 100자 이하여야 합니다")
     private String apmsNoticeNo;
 
@@ -78,10 +80,10 @@ public class CreateAnimalRequest {
     private AnimalStatus status;
 
     /**
-     * 데이터 출처
+     * 데이터 출처 (선택, 기본값: MANUAL)
      * - MANUAL(수동등록), APMS_ANIMAL(APMS API) 등
+     * - 미입력 시 MANUAL로 처리
      */
-    @NotNull(message = "데이터 출처는 필수입니다")
     private ApiSource apiSource;
 
     // 선택 필드 (9개)

--- a/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/repository/AnimalRepository.java
@@ -154,4 +154,12 @@ public interface AnimalRepository extends JpaRepository<Animal, Long>,
      */
     @Query("SELECT a FROM Animal a WHERE a.status = 'PROTECT' AND a.noticeEndDate < :today")
     List<Animal> findExpiredProtectAnimals(@Param("today") LocalDate today);
+
+    /**
+     * 특정 prefix로 시작하는 공고번호 개수 조회
+     * - 수동 등록 순번 생성용
+     * @param prefix 공고번호 prefix (예: "MAN-251230-")
+     * @return 개수
+     */
+    long countByApmsNoticeNoStartingWith(String prefix);
 }

--- a/animal-service/src/main/java/com/pawbridge/animalservice/service/NoticeNumberGenerator.java
+++ b/animal-service/src/main/java/com/pawbridge/animalservice/service/NoticeNumberGenerator.java
@@ -1,0 +1,44 @@
+package com.pawbridge.animalservice.service;
+
+import com.pawbridge.animalservice.repository.AnimalRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 수동 등록 동물의 공고번호 생성기
+ * - 형식: MAN-{YYMMDD}-{6자리순번}
+ * - 예: MAN-251230-000001
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NoticeNumberGenerator {
+
+    private static final String PREFIX = "MAN";
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyMMdd");
+
+    private final AnimalRepository animalRepository;
+
+    /**
+     * 수동 등록용 공고번호 생성
+     * @return 고유한 공고번호
+     */
+    public String generate() {
+        String today = LocalDate.now().format(DATE_FORMAT);
+        String prefix = PREFIX + "-" + today + "-";
+
+        // 오늘 날짜의 마지막 순번 조회
+        long count = animalRepository.countByApmsNoticeNoStartingWith(prefix);
+        long nextNumber = count + 1;
+
+        // 6자리 순번 (000001 ~ 999999)
+        String noticeNo = prefix + String.format("%06d", nextNumber);
+
+        log.info("수동 등록 공고번호 생성: {}", noticeNo);
+        return noticeNo;
+    }
+}


### PR DESCRIPTION
## 변경 사항

수동 동물 등록 기능 개선
- 공고번호 자동 생성: 수동 등록 시 apmsNoticeNo 미입력하면 MAN-{YYMMDD}-{6자리순번} 형식으로 자동 생성
- shelterId → careRegNo 변경: 동물 등록 요청 시 보호소 등록번호 사용으로 변경
- API 문서 업데이트: 수동 등록 API 명세 추가, 로그인 응답 필드 문서화

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가
- [ ] 설정 변경

## 관련 이슈
Closes #117 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)