### PR TITLE
feat(api-gateway): 동물/보호소 조회 비회원 접근 허용

### DIFF
--- a/api-gateway/src/main/java/com/pawbridge/apigateway/filter/JwtAuthorizationGatewayFilterFactory.java
+++ b/api-gateway/src/main/java/com/pawbridge/apigateway/filter/JwtAuthorizationGatewayFilterFactory.java
@@ -44,7 +44,13 @@ public class JwtAuthorizationGatewayFilterFactory
             "/api/v1/posts/read/*",                // 게시글 단건 조회
             "/api/v1/posts/read",                   // 게시글 목록 조회
             "/api/v1/posts/search",                 // 검색
-            "/api/v1/comments/posts/read/*"        // 특정 게시글 댓글 목록 조회
+            "/api/v1/comments/posts/read/*",       // 특정 게시글 댓글 목록 조회
+            // 동물 관련 공개 API
+            "/api/v1/animals",                     // 동물 목록 조회
+            "/api/v1/animals/*",                   // 동물 상세 조회
+            "/api/v1/animals/expiring-soon",       // 공고 종료 임박 동물
+            "/api/v1/shelters",                    // 보호소 목록 조회
+            "/api/v1/shelters/*"                   // 보호소 상세 조회
     );
 
     // ROLE_ADMIN만 접근 가능한 경로 (프론트엔드 요청 기준, v1 없음)


### PR DESCRIPTION
## 변경 사항
동물 및 보호소 조회 API를 비회원도 접근할 수 있도록 API Gateway 화이트리스트에 추가했습니다.

### 추가된 화이트리스트 경로
- GET /api/v1/animals - 동물 목록 조회
- GET /api/v1/animals/* - 동물 상세 조회
- GET /api/v1/animals/expiring-soon - 공고 종료 임박 동물
- GET /api/v1/shelters - 보호소 목록 조회
- GET /api/v1/shelters/* - 보호소 상세 조회

### 변경 이유
- 유기동물/보호소 정보는 공개 데이터로 로그인 없이 열람 가능해야 함
- 회원가입 전 서비스 탐색 가능하도록 UX 개선

## 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #119 

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [ ] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
기존 ADMIN_ONLY_PATHS, NON_USER_PATHS와 충돌 없음 확인 완료.
화이트리스트는 GET 요청만 해당되며, POST/PUT/PATCH/DELETE는 기존 권한 체크 유지됩니다.