### PR TITLE
hotfix(monitoring): prometheus.yml envsubst 환경변수 치환 적용

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -14,7 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # 1. 모니터링 설정 파일 전송
+      # 1. prometheus.yml 환경변수 치환
+      - name: Replace environment variables in prometheus.yml
+        run: |
+          export NODE2_PRIVATE_IP=${{ secrets.NODE2_PRIVATE_IP }}
+          export NODE3_PRIVATE_IP=${{ secrets.NODE3_PRIVATE_IP }}
+          export NODE4_PRIVATE_IP=${{ secrets.NODE4_PRIVATE_IP }}
+          export NODE5_PRIVATE_IP=${{ secrets.NODE5_PRIVATE_IP }}
+          envsubst < infrastructure/prod/prometheus/prometheus.yml > prometheus.yml.tmp
+          mv prometheus.yml.tmp infrastructure/prod/prometheus/prometheus.yml
+
+      # 2. 모니터링 설정 파일 전송
       - name: Copy Monitoring Config to Node-1
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
## 변경 사항
- deploy-monitoring.yml에 envsubst 단계 추가
- prometheus.yml 환경변수(NODE*_PRIVATE_IP)를 배포 시 실제 IP로 치환

## 작업 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
- [x] 설정 변경

## 관련 이슈
Closes #121

## 체크리스트
- [x] 코드가 정상적으로 빌드됨
- [ ] 테스트가 모두 통과함
- [x] 코드 스타일 가이드를 따름
- [x] 주석이 적절히 작성됨
- [x] 문서가 업데이트됨 (필요한 경우)

## 추가 설명
Prometheus가 환경변수 치환을 지원하지 않아 GitHub Actions에서 envsubst로 미리 치환